### PR TITLE
Unicode docstrings are not handled correctly on Python 2.x

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -50,7 +50,7 @@ def mangle_docstrings(app, what, name, obj, options, lines,
         if sys.version_info[0] >= 3:
             doc = str(doc)
         else:
-            doc = str(doc).decode('utf-8')
+            doc = unicode(doc)
         lines[:] = doc.split(sixu("\n"))
 
     if app.config.numpydoc_edit_link and hasattr(obj, '__name__') and \
@@ -182,4 +182,3 @@ def wrap_mangling_directive(base_directive, objtype):
             return base_directive.run(self)
 
     return directive
-


### PR DESCRIPTION
If a docstring is Unicode on Python 2.x, Numpydoc will crash with a `UnicodeEncodeError`.  This is because it calls `str` on the `SphinxDocString` object, calling `SphinxDocString.__str__` which returns unicode when the docstring itself is unicode.  Python then fails converting that unicode object to a bytes (str) object using the default encoding.

```
# -*- coding: utf-8 -*-

docstring = u"""
numpydoc הוא מדהים
"""

from numpydoc import docscrape_sphinx

d = docscrape_sphinx.SphinxDocString(docstring)

x = str(d)  # fails
x = unicode(d)  # works, whether docstring is unicode or bytes
```

This PR restores the behavior in the numpydoc that ships with Numpy 1.7.1, which was to keep unicode as-is, and convert bytes to unicode using the default encoding.
