### PR TITLE
Bump version since 0.4 has been released some time ago.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from distutils.core import setup
 if sys.version_info[:2] < (2, 6) or (3, 0) <= sys.version_info[0:2] < (3, 3):
     raise RuntimeError("Python version 2.6, 2.7 or >= 3.3 required.")
 
-version = "0.4.dev"
+version = "0.5.dev"
 
 setup(
     name="numpydoc",


### PR DESCRIPTION
Since version 0.4 is released and available on [pypi](https://pypi.python.org/pypi/numpydoc/0.4) 
`pip list --outdated` will report an install from the master branch (0.4.dev) as outdated since 0.4.dev < 0.4. 
This just bumps the version to fix that it seems in line with standard pre release version numbers and the ones used for numpy.  
