### PR TITLE
ENH: Convert TeX inline math, $...$, into ReST :math:`...`

### DIFF
--- a/numpydoc/tests/test_convert_tex.py
+++ b/numpydoc/tests/test_convert_tex.py
@@ -1,0 +1,55 @@
+from __future__ import division, print_function, absolute_import
+
+import nose
+from nose.tools import assert_raises
+from numpydoc.numpydoc import convert_tex
+
+
+good_pairs = [
+    ("",
+     ""),
+
+    ("a quick brown fox", 
+     "a quick brown fox"),
+
+    ("$a quick brown fox$", 
+     ":math:`a quick brown fox`"),
+
+    ("Let $x$ equal $2^{42}$",
+     "Let :math:`x` equal :math:`2^{42}`"),
+
+    ("$x$ being an unknown",
+     ":math:`x` being an unknown"),
+
+    (r"For $xi\to 0$, $\sin(1/\xi)$ is undefined",
+     r"For :math:`xi\to 0`, :math:`\sin(1/\xi)` is undefined"),
+
+    ("For $x\\to 0$, $\\sin(1/x)$ is undefined",
+     "For :math:`x\\to 0`, :math:`\\sin(1/x)` is undefined"),
+]
+
+
+# these should fail loudly
+bad_ones = [
+    "$$",
+    "$$sorry, no displaymath$$",
+    "and $math$ better fit in one $line",
+]
+
+
+def test_bad():
+    for line in bad_ones:
+        yield assert_raises, ValueError, convert_tex, line
+
+
+def test_good():
+    for inp, outp in good_pairs:
+        yield check_pair, inp, outp
+
+
+def check_pair(inp, outp):
+    assert convert_tex(inp) == outp
+
+
+if __name__ == "__main__":
+    nose.run()


### PR DESCRIPTION
This is deliberately simplistic: no displaymath, only deal with expressions which fit in a single line.

The itch I'm scratching is the desire to be able to write things like

```
.. math::
     I_0^{(2)}(x) = ...

where $x$ is ... 
```

without having to type :math: for each one-letter variable. 
