### PR TITLE
Support Yields section.

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -292,8 +292,9 @@ class NumpyDocString(object):
         for (section,content) in self._read_sections():
             if not section.startswith('..'):
                 section = ' '.join([s.capitalize() for s in section.split(' ')])
-            if section in ('Parameters', 'Returns', 'Raises', 'Warns',
-                           'Other Parameters', 'Attributes', 'Methods'):
+            if section in ('Parameters', 'Returns', 'Yields', 'Raises',
+                           'Warns', 'Other Parameters', 'Attributes',
+                           'Methods'):
                 self[section] = self._parse_param_list(content)
             elif section.startswith('.. index::'):
                 self['index'] = self._parse_index(section, content)

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -289,7 +289,17 @@ class NumpyDocString(object):
         self._doc.reset()
         self._parse_summary()
 
-        for (section,content) in self._read_sections():
+        sections = list(self._read_sections())
+        section_names = set([section for section, content in sections])
+
+        has_returns = 'Returns' in section_names
+        has_yields = 'Yields' in section_names
+        # We could do more tests, but we are not. Arbitrarily.
+        if has_returns and has_yields:
+            msg = 'Docstring contains both a Returns and Yields section.'
+            raise ValueError(msg)
+
+        for (section, content) in sections:
             if not section.startswith('..'):
                 section = ' '.join([s.capitalize() for s in section.split(' ')])
             if section in ('Parameters', 'Returns', 'Yields', 'Raises',

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -97,6 +97,7 @@ class NumpyDocString(object):
             'Extended Summary': [],
             'Parameters': [],
             'Returns': [],
+            'Yields': [],
             'Raises': [],
             'Warns': [],
             'Other Parameters': [],

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -224,7 +224,7 @@ class SphinxDocString(NumpyDocString):
         out += self._str_summary()
         out += self._str_extended_summary()
         out += self._str_param_list('Parameters')
-        out += self._str_returns()
+        out += self._str_returns('Returns')
         out += self._str_returns('Yields')
         for param_list in ('Other Parameters', 'Raises', 'Warns'):
             out += self._str_param_list(param_list)

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -46,12 +46,12 @@ class SphinxDocString(NumpyDocString):
     def _str_extended_summary(self):
         return self['Extended Summary'] + ['']
 
-    def _str_returns(self):
+    def _str_returns(self, name='Returns'):
         out = []
-        if self['Returns']:
-            out += self._str_field_list('Returns')
+        if self[name]:
+            out += self._str_field_list(name)
             out += ['']
-            for param, param_type, desc in self['Returns']:
+            for param, param_type, desc in self[name]:
                 if param_type:
                     out += self._str_indent(['**%s** : %s' % (param.strip(),
                                                               param_type)])
@@ -225,7 +225,7 @@ class SphinxDocString(NumpyDocString):
         out += self._str_extended_summary()
         out += self._str_param_list('Parameters')
         out += self._str_returns()
-        out += self._str_param_list('Yields')
+        out += self._str_returns('Yields')
         for param_list in ('Other Parameters', 'Raises', 'Warns'):
             out += self._str_param_list(param_list)
         out += self._str_warnings()

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -63,6 +63,23 @@ class SphinxDocString(NumpyDocString):
                 out += ['']
         return out
 
+    def _str_yields(self):
+        out = []
+        if self['Yields']:
+            out += self._str_field_list('Yields')
+            out += ['']
+            for param, param_type, desc in self['Yields']:
+                if param_type:
+                    out += self._str_indent(['**%s** : %s' % (param.strip(),
+                                                              param_type)])
+                else:
+                    out += self._str_indent([param.strip()])
+                if desc:
+                    out += ['']
+                    out += self._str_indent(desc, 8)
+                out += ['']
+        return out
+
     def _str_param_list(self, name):
         out = []
         if self[name]:

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -164,6 +164,29 @@ def test_returns():
     assert desc[0].startswith('This is not a real')
     assert desc[-1].endswith('anonymous return values.')
 
+def test_yields():
+    doc_text = """
+Test generator
+
+Yields
+------
+a : int
+    The number of apples.
+b : int
+    The number of bananas.
+
+"""
+    doc = NumpyDocString(doc_text)
+    section = doc['Yields']
+    print(section)
+    assert_equal(len(section), 2)
+    truth = [('a', 'apples.'), ('b', 'bananas.')]
+    for (arg, arg_type, desc), (arg_true, ending) in zip(section, truth):
+        assert_equal(arg, arg_true)
+        assert_equal(arg_type, 'int')
+        assert desc[0].startswith('The number of')
+        assert desc[0].endswith(ending)
+
 def test_notes():
     assert doc['Notes'][0].startswith('Instead')
     assert doc['Notes'][-1].endswith('definite.')

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -122,6 +122,20 @@ doc_txt = '''\
   '''
 doc = NumpyDocString(doc_txt)
 
+doc_yields_txt = """
+Test generator
+
+Yields
+------
+a : int
+    The number of apples.
+b : int
+    The number of bananas.
+int
+    The number of unknowns.
+"""
+doc_yields = NumpyDocString(doc_yields_txt)
+
 
 def test_signature():
     assert doc['Signature'].startswith('numpy.multivariate_normal(')
@@ -165,8 +179,25 @@ def test_returns():
     assert desc[-1].endswith('anonymous return values.')
 
 def test_yields():
+    section = doc_yields['Yields']
+    assert_equal(len(section), 3)
+    truth = [('a', 'int', 'apples.'),
+             ('b', 'int', 'bananas.'),
+             ('int', '', 'unknowns.')]
+    for (arg, arg_type, desc), (arg_, arg_type_, end) in zip(section, truth):
+        assert_equal(arg, arg_)
+        assert_equal(arg_type, arg_type_)
+        assert desc[0].startswith('The number of')
+        assert desc[0].endswith(end)
+
+def test_returnyield():
     doc_text = """
-Test generator
+Test having returns and yields.
+
+Returns
+-------
+int
+    The number of apples.
 
 Yields
 ------
@@ -176,15 +207,7 @@ b : int
     The number of bananas.
 
 """
-    doc = NumpyDocString(doc_text)
-    section = doc['Yields']
-    assert_equal(len(section), 2)
-    truth = [('a', 'apples.'), ('b', 'bananas.')]
-    for (arg, arg_type, desc), (arg_true, ending) in zip(section, truth):
-        assert_equal(arg, arg_true)
-        assert_equal(arg_type, 'int')
-        assert desc[0].startswith('The number of')
-        assert desc[0].endswith(ending)
+    assert_raises(ValueError, NumpyDocString, doc_text)
 
 def test_notes():
     assert doc['Notes'][0].startswith('Instead')
@@ -215,6 +238,9 @@ def non_blank_line_by_line_compare(a,b):
                                  "\n>>> %s\n<<< %s\n" %
                                  (n,line,b[n]))
 def test_str():
+    # doc_txt has the order of Notes and See Also sections flipped.
+    # This should be handled automatically, and so, one thing this test does
+    # is to make sure that See Also precedes Notes in the output.
     non_blank_line_by_line_compare(str(doc),
 """numpy.multivariate_normal(mean, cov, shape=None, spam=None)
 
@@ -322,6 +348,22 @@ standard deviation:
 
 .. index:: random
    :refguide: random;distributions, random;gauss""")
+
+
+def test_yield_str():
+    non_blank_line_by_line_compare(str(doc_yields),
+"""Test generator
+
+Yields
+------
+a : int
+    The number of apples.
+b : int
+    The number of bananas.
+int
+    The number of unknowns.
+
+.. index:: """)
 
 
 def test_sphinx_str():
@@ -446,6 +488,27 @@ standard deviation:
 
 >>> print list( (x[0,0,:] - mean) < 0.6 )
 [True, True]
+""")
+
+
+def test_sphinx_yields_str():
+    sphinx_doc = SphinxDocString(doc_yields_txt)
+    non_blank_line_by_line_compare(str(sphinx_doc),
+"""Test generator
+
+:Yields:
+
+    **a** : int
+
+        The number of apples.
+
+    **b** : int
+
+        The number of bananas.
+
+    int
+
+        The number of unknowns.
 """)
 
 

--- a/numpydoc/traitsdoc.py
+++ b/numpydoc/traitsdoc.py
@@ -61,6 +61,7 @@ class SphinxTraitsDoc(SphinxClassDoc):
             'Extended Summary': [],
             'Parameters': [],
             'Returns': [],
+            'Yields': [],
             'Raises': [],
             'Warns': [],
             'Other Parameters': [],

--- a/numpydoc/traitsdoc.py
+++ b/numpydoc/traitsdoc.py
@@ -90,7 +90,7 @@ class SphinxTraitsDoc(SphinxClassDoc):
         out += self._str_summary()
         out += self._str_extended_summary()
         for param_list in ('Parameters', 'Traits', 'Methods',
-                           'Returns','Raises'):
+                           'Returns', 'Yields', 'Raises'):
             out += self._str_param_list(param_list)
         out += self._str_see_also("obj")
         out += self._str_section('Notes')


### PR DESCRIPTION
For generators, a Yields section is more helpful than a Returns section.

For some reason, I thought Yields was already supported by numpydoc. I guess not.
Napoleon supports it: http://sphinxcontrib-napoleon.readthedocs.org/