### PR TITLE
BUG: fix spacing in sphinx class doc attribute listing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 language: python
+sudo: false
 python:
   - 3.3
   - 2.7
+cache:
+  directories:
+    - $HOME/.cache/pip
 before_install:
   - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
-  - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --use-wheel --use-mirrors nose numpy matplotlib Sphinx
+  - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --trusted-host wheels.astropy.org --trusted-host wheels2.astropy.org --use-wheel nose numpy matplotlib Sphinx
 script:
   - python setup.py test

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -130,7 +130,7 @@ class SphinxDocString(NumpyDocString):
                 maxlen_0 = max(3, max([len(x[0]) for x in others]))
                 hdr = sixu("=")*maxlen_0 + sixu("  ") + sixu("=")*10
                 fmt = sixu('%%%ds  %%s  ') % (maxlen_0,)
-                out += ['', hdr]
+                out += ['', '', hdr]
                 for param, param_type, desc in others:
                     desc = sixu(" ").join(x.strip() for x in desc).strip()
                     if param_type:

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -677,6 +677,8 @@ class_doc_txt = """
         Current time.
     y : ndarray
         Current variable values.
+    x : float
+        Some parameter
 
     Methods
     -------
@@ -712,6 +714,8 @@ def test_class_members_doc():
         Current time.
     y : ndarray
         Current variable values.
+    x : float
+        Some parameter
 
     Methods
     -------
@@ -726,7 +730,13 @@ def test_class_members_doc():
     """)
 
 def test_class_members_doc_sphinx():
-    doc = SphinxClassDoc(None, class_doc_txt)
+    class Foo:
+        @property
+        def x(self):
+            """Test attribute"""
+            return None
+
+    doc = SphinxClassDoc(Foo, class_doc_txt)
     non_blank_line_by_line_compare(str(doc),
     """
     Foo
@@ -746,6 +756,11 @@ def test_class_members_doc_sphinx():
     For usage examples, see `ode`.
 
     .. rubric:: Attributes
+
+    .. autosummary::
+       :toctree:
+
+       x
 
     ===  ==========
       t  (float) Current time.


### PR DESCRIPTION
Previously, it produced  `(WARNING/2) Explicit markup ends without a blank line; unexpected unindent` errors due to the missing newline.