### PR TITLE
MAINT inspect.getfullargspec is deprecated in Py3.5

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -460,15 +460,17 @@ class FunctionDoc(NumpyDocString):
         if not self['Signature'] and func is not None:
             func, func_name = self.get_func()
             try:
-                # try to read signature
-                if sys.version_info[0] >= 3:
-                    argspec = inspect.getfullargspec(func)
+                if hasattr(inspect, 'signature'):
+                    signature = str(inspect.signature(func))
                 else:
-                    argspec = inspect.getargspec(func)
-                argspec = inspect.formatargspec(*argspec)
-                argspec = argspec.replace('*', '\*')
-                signature = '%s%s' % (func_name, argspec)
-            except TypeError as e:
+                    # try to read signature, backward compat for older Python
+                    if sys.version_info[0] >= 3:
+                        argspec = inspect.getfullargspec(func)
+                    else:
+                        argspec = inspect.getargspec(func)
+                    signature = inspect.formatargspec(*argspec)
+                signature = '%s%s' % (func_name, signature.replace('*', '\*'))
+            except TypeError:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -536,6 +536,12 @@ def test_escape_stars():
     signature = str(doc3).split('\n')[0]
     assert_equal(signature, 'my_signature(\*params, \*\*kwds)')
 
+    def my_func(a, b, **kwargs):
+        pass
+
+    fdoc = FunctionDoc(func=my_func)
+    assert_equal(fdoc['Signature'], 'my_func(a, b, \*\*kwargs)')
+
 doc4 = NumpyDocString(
     """a.conj()
 


### PR DESCRIPTION
And the code is much nicer with the new signature API.