### PR TITLE
numpydoc.docscrape: Restore support for Python 3.4.

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -473,9 +473,9 @@ class FunctionDoc(NumpyDocString):
         if not self['Signature'] and func is not None:
             func, func_name = self.get_func()
             try:
-                if hasattr(inspect, 'signature'):
+                try:
                     signature = str(inspect.signature(func))
-                else:
+                except (AttributeError, ValueError):
                     # try to read signature, backward compat for older Python
                     if sys.version_info[0] >= 3:
                         argspec = inspect.getfullargspec(func)


### PR DESCRIPTION
Fixing backwards compatibility bug introduced in commit
254494c, which broke support for Python 3.4 when passing
the builtin method 'mro' of 'type' objects to
'inspect.signature', raising a 'ValueError'.