### PR TITLE
REL: use the distutils sdist command instead of the setuptools one.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,8 @@
+include MANIFEST.in
 recursive-include numpydoc/tests *.py
 include *.txt
+include *.rst
+
+# Exclude what we don't want to include
+prune */__pycache__
+global-exclude *.pyc *~ *.bak *.swp *.pyo

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from __future__ import division, print_function
 
 import sys
+
+from distutils.command.sdist import sdist
 import setuptools
 from distutils.core import setup
 
@@ -27,4 +29,5 @@ setup(
     requires=["sphinx (>= 1.0.1)"],
     package_data={'numpydoc': ['tests/test_*.py']},
     test_suite = 'nose.collector',
+    cmdclass={"sdist": sdist},
 )


### PR DESCRIPTION
This removed unwanted useless files: an empty ``setup.cfg`` and a ``numpy.egg-info`` directory.