### PR TITLE
Fix/enhance replacement of citation reference numbers to avoid duplicates

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -37,8 +37,34 @@ else:
     sixu = lambda s: unicode(s, 'unicode_escape')
 
 
-def mangle_docstrings(app, what, name, obj, options, lines,
+def rename_references(app, what, name, obj, options, lines,
                       reference_offset=[0]):
+    # replace reference numbers so that there are no duplicates
+    references = []
+    for line in lines:
+        line = line.strip()
+        m = re.match(sixu('^.. \\[([a-z0-9_.-])\\]'), line, re.I)
+        if m:
+            references.append(m.group(1))
+
+    # start renaming from the longest string, to avoid overwriting parts
+    references.sort(key=lambda x: -len(x))
+    if references:
+        for i, line in enumerate(lines):
+            for r in references:
+                if re.match(sixu('^\\d+$'), r):
+                    new_r = sixu("R%d") % (reference_offset[0] + int(r))
+                else:
+                    new_r = sixu("%s%d") % (r, reference_offset[0])
+                lines[i] = lines[i].replace(sixu('[%s]_') % r,
+                                            sixu('[%s]_') % new_r)
+                lines[i] = lines[i].replace(sixu('.. [%s]') % r,
+                                            sixu('.. [%s]') % new_r)
+
+    reference_offset[0] += len(references)
+
+
+def mangle_docstrings(app, what, name, obj, options, lines):
 
     cfg = {'use_plots': app.config.numpydoc_use_plots,
            'show_class_members': app.config.numpydoc_show_class_members,
@@ -70,29 +96,9 @@ def mangle_docstrings(app, what, name, obj, options, lines,
         lines += [sixu('    %s') % x for x in
                   (app.config.numpydoc_edit_link % v).split("\n")]
 
-    # replace reference numbers so that there are no duplicates
-    references = []
-    for line in lines:
-        line = line.strip()
-        m = re.match(sixu('^.. \\[([a-z0-9_.-])\\]'), line, re.I)
-        if m:
-            references.append(m.group(1))
-
-    # start renaming from the longest string, to avoid overwriting parts
-    references.sort(key=lambda x: -len(x))
-    if references:
-        for i, line in enumerate(lines):
-            for r in references:
-                if re.match(sixu('^\\d+$'), r):
-                    new_r = sixu("R%d") % (reference_offset[0] + int(r))
-                else:
-                    new_r = sixu("%s%d") % (r, reference_offset[0])
-                lines[i] = lines[i].replace(sixu('[%s]_') % r,
-                                            sixu('[%s]_') % new_r)
-                lines[i] = lines[i].replace(sixu('.. [%s]') % r,
-                                            sixu('.. [%s]') % new_r)
-
-    reference_offset[0] += len(references)
+    # call function to replace reference numbers so that there are no
+    # duplicates
+    rename_references(app, what, name, obj, options, lines)
 
 
 def mangle_signature(app, what, name, obj, options, sig, retann):

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -47,8 +47,6 @@ def rename_references(app, what, name, obj, options, lines,
         if m:
             references.append(m.group(1))
 
-    # start renaming from the longest string, to avoid overwriting parts
-    references.sort(key=lambda x: -len(x))
     if references:
         for i, line in enumerate(lines):
             for r in references:

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -134,7 +134,7 @@ def setup(app, get_doc_object_=get_doc_object):
     app.add_config_value('numpydoc_show_class_members', True, True)
     app.add_config_value('numpydoc_show_inherited_class_members', True, True)
     app.add_config_value('numpydoc_class_members_toctree', True, True)
-    app.add_config_value('numpydoc_citation_re', '[a-z0-9_.-]', True)
+    app.add_config_value('numpydoc_citation_re', '[a-z0-9_.-]+', True)
 
     # Extra mangling domains
     app.add_domain(NumpyPythonDomain)

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -43,7 +43,8 @@ def rename_references(app, what, name, obj, options, lines,
     references = []
     for line in lines:
         line = line.strip()
-        m = re.match(sixu('^.. \\[([a-z0-9_.-])\\]'), line, re.I)
+        m = re.match(sixu('^.. \\[(%s)\\]') % app.config.numpydoc_citation_re,
+                     line, re.I)
         if m:
             references.append(m.group(1))
 
@@ -133,6 +134,7 @@ def setup(app, get_doc_object_=get_doc_object):
     app.add_config_value('numpydoc_show_class_members', True, True)
     app.add_config_value('numpydoc_show_inherited_class_members', True, True)
     app.add_config_value('numpydoc_class_members_toctree', True, True)
+    app.add_config_value('numpydoc_citation_re', '[a-z0-9_.-]', True)
 
     # Extra mangling domains
     app.add_domain(NumpyPythonDomain)


### PR DESCRIPTION
This is meant to fix bug #49 and more.

Changes are meant to:

- Factor out the reference number replacement code in its own function
   - So that other extensions can replace this functionality should this be needed.
- Remove unused code from the reference number replacement routine
- Make the pattern used to identify the references configurable
   - This is meant to allow the user to decide what should be replaced. Such functionality can be extremely useful for two reasons: (i) in case the change in the default pattern (see next point) ends up breaking something and one explicitly wants the older numpydoc matching for references; and (ii), most important, to allow duplicates to be managed at a different level in sphinx.
- Change the default pattern used to identify references from  `[a-z0-9_.-]` to `[a-z0-9_.-]+`
   - so that multidigit entries are recognized (e.g. [10])
