### PR TITLE
allow extending NumpyDocString sections

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -97,30 +97,32 @@ class ParseError(Exception):
 
 
 class NumpyDocString(collections.Mapping):
+    sections = {
+        'Signature': '',
+        'Summary': [''],
+        'Extended Summary': [],
+        'Parameters': [],
+        'Returns': [],
+        'Yields': [],
+        'Raises': [],
+        'Warns': [],
+        'Other Parameters': [],
+        'Attributes': [],
+        'Methods': [],
+        'See Also': [],
+        'Notes': [],
+        'Warnings': [],
+        'References': '',
+        'Examples': '',
+        'index': {}
+    }
+
     def __init__(self, docstring, config={}):
         orig_docstring = docstring
         docstring = textwrap.dedent(docstring).split('\n')
 
         self._doc = Reader(docstring)
-        self._parsed_data = {
-            'Signature': '',
-            'Summary': [''],
-            'Extended Summary': [],
-            'Parameters': [],
-            'Returns': [],
-            'Yields': [],
-            'Raises': [],
-            'Warns': [],
-            'Other Parameters': [],
-            'Attributes': [],
-            'Methods': [],
-            'See Also': [],
-            'Notes': [],
-            'Warnings': [],
-            'References': '',
-            'Examples': '',
-            'index': {}
-            }
+        self._parsed_data = NumpyDocString.sections.copy()
 
         try:
             self._parse()

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -9,6 +9,7 @@ import re
 import pydoc
 from warnings import warn
 import collections
+import copy
 import sys
 
 
@@ -122,7 +123,7 @@ class NumpyDocString(collections.Mapping):
         docstring = textwrap.dedent(docstring).split('\n')
 
         self._doc = Reader(docstring)
-        self._parsed_data = NumpyDocString.sections.copy()
+        self._parsed_data = copy.deepcopy(self.sections)
 
         try:
             self._parse()


### PR DESCRIPTION
Current implementation of NumpyDocString define sections in
`self._parsed_data` in `NumpyDocString.__init__()`, which is not
convenient for developers to extend this class to add more sections. By
setting section definitions as a class static variable, it will be more
convenient for developers to extend more sections by changing the class
static variable `sections`.