### PR TITLE
Use setuptools 'install_requires' instead of 'requires' in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author_email="pav@iki.fi",
     url="https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt",
     license="BSD",
-    requires=["sphinx (>= 1.0.1)"],
+    install_requires=["sphinx (>= 1.0.1)"],
     package_data={'numpydoc': ['tests/test_*.py']},
     test_suite = 'nose.collector',
     cmdclass={"sdist": sdist},


### PR DESCRIPTION
This will trigger sphinx installation when installing numpydoc (tested locally). See https://github.com/numpy/numpydoc/issues/55