### PR TITLE
bold attributes so we don't have to deal with trailing underscores

### DIFF
--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -132,15 +132,15 @@ class SphinxDocString(NumpyDocString):
                 out += [''] + autosum
 
             if others:
-                maxlen_0 = max(3, max([len(x[0]) for x in others]))
-                hdr = sixu("=")*maxlen_0 + sixu("  ") + sixu("=")*10
+                maxlen_0 = max(3, max([len(x[0]) + 4 for x in others]))
+                hdr = sixu("=") * maxlen_0 + sixu("  ") + sixu("=") * 10
                 fmt = sixu('%%%ds  %%s  ') % (maxlen_0,)
                 out += ['', '', hdr]
                 for param, param_type, desc in others:
                     desc = sixu(" ").join(x.strip() for x in desc).strip()
                     if param_type:
                         desc = "(%s) %s" % (param_type, desc)
-                    out += [fmt % (param.strip(), desc)]
+                    out += [fmt % ("**" + param.strip() + "**", desc)]
                 out += [hdr]
             out += ['']
         return out

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -893,18 +893,18 @@ def test_class_members_doc_sphinx():
 
        x
 
-    ===  ==========
-      t  (float) Current time.
-      y  (ndarray) Current variable values.
-    ===  ==========
+    =====  ==========
+    **t**  (float) Current time.
+    **y**  (ndarray) Current variable values.
+    =====  ==========
 
     .. rubric:: Methods
 
-    ===  ==========
-      a
-      b
-      c
-    ===  ==========
+    =====  ==========
+    **a**
+    **b**
+    **c**
+    =====  ==========
 
     """)
 


### PR DESCRIPTION
Also looks better.

Fixes #62.

If the bold formatting is not for you, we can do backticks instead. I feel that attributes should be literals, not interpreted by sphinx.