### PR TITLE
Raises an error when a section is present twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@
 *.pyc
 *.pyo
 *.egg-info
+*.swp
+*.swo
 build
 dist

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -327,7 +327,7 @@ class NumpyDocString(collections.Mapping):
             if not section.startswith('..'):
                 section = (s.capitalize() for s in section.split(' '))
                 section = ' '.join(section)
-                if self[section]:
+                if self.get(section):
                     msg = ("The section %s appears twice in the docstring." %
                            section)
                     raise ValueError(msg)

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -327,6 +327,11 @@ class NumpyDocString(collections.Mapping):
             if not section.startswith('..'):
                 section = (s.capitalize() for s in section.split(' '))
                 section = ' '.join(section)
+                if self[section]:
+                    msg = ("The section %s appears twice in the docstring." %
+                           section)
+                    raise ValueError(msg)
+
             if section in ('Parameters', 'Returns', 'Yields', 'Raises',
                            'Warns', 'Other Parameters', 'Attributes',
                            'Methods'):

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -209,6 +209,22 @@ b : int
 """
     assert_raises(ValueError, NumpyDocString, doc_text)
 
+
+def test_section_twice():
+    doc_text = """
+Test having a section Notes twice
+
+Notes
+-----
+See the next note for more information
+
+Notes
+-----
+That should break...
+"""
+    assert_raises(ValueError, NumpyDocString, doc_text)
+
+
 def test_notes():
     assert doc['Notes'][0].startswith('Instead')
     assert doc['Notes'][-1].endswith('definite.')


### PR DESCRIPTION
The previous behavior overwrote the content of the first section with the second.

Now, it raises a value error.

I also added some elements to gitignore for vim users.

closes #64 