### PR TITLE
Render numpydoc strings from a template

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -77,7 +77,8 @@ def mangle_docstrings(app, what, name, obj, options, lines):
         title_re = re.compile(sixu(pattern), re.I | re.S)
         lines[:] = title_re.sub(sixu(''), u_NL.join(lines)).split(u_NL)
     else:
-        doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg)
+        doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg,
+                             builder=app.builder)
         if sys.version_info[0] >= 3:
             doc = str(doc)
         else:

--- a/numpydoc/templates/numpydoc_docstring.rst
+++ b/numpydoc/templates/numpydoc_docstring.rst
@@ -1,0 +1,16 @@
+{{index}}
+{{summary}}
+{{extended_summary}}
+{{parameters}}
+{{returns}}
+{{yields}}
+{{other_parameters}}
+{{raises}}
+{{warns}}
+{{warnings}}
+{{see_also}}
+{{notes}}
+{{references}}
+{{examples}}
+{{attributes}}
+{{methods}}

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -2,6 +2,9 @@
 from __future__ import division, absolute_import, print_function
 
 import sys, textwrap
+import io
+
+import jinja2
 
 from numpydoc.docscrape import NumpyDocString, FunctionDoc, ClassDoc
 from numpydoc.docscrape_sphinx import SphinxDocString, SphinxClassDoc
@@ -248,11 +251,8 @@ def non_blank_line_by_line_compare(a,b):
     b = textwrap.dedent(b)
     a = [l.rstrip() for l in a.split('\n') if l.strip()]
     b = [l.rstrip() for l in b.split('\n') if l.strip()]
-    for n,line in enumerate(a):
-        if not line == b[n]:
-            raise AssertionError("Lines %s of a and b differ: "
-                                 "\n>>> %s\n<<< %s\n" %
-                                 (n,line,b[n]))
+    assert_list_equal(a, b)
+
 def test_str():
     # doc_txt has the order of Notes and See Also sections flipped.
     # This should be handled automatically, and so, one thing this test does
@@ -923,6 +923,29 @@ def test_class_members_doc_sphinx():
     =====  ==========
 
     """)
+
+def test_templated_sections():
+    doc = SphinxClassDoc(None, class_doc_txt,
+                         config={'template': jinja2.Template('{{examples}}{{parameters}}')})
+    non_blank_line_by_line_compare(str(doc),
+    """
+    .. rubric:: Examples
+
+    For usage examples, see `ode`.
+
+
+    :Parameters:
+
+        **f** : callable ``f(t, y, *f_args)``
+
+            Aaa.
+
+        **jac** : callable ``jac(t, y, *jac_args)``
+
+            Bbb.
+
+    """)
+
 
 if __name__ == "__main__":
     import nose

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     author_email="pav@iki.fi",
     url="https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt",
     license="BSD",
-    install_requires=["sphinx >= 1.0.1"],
+    install_requires=["sphinx >= 1.0.1", 'Jinja2>=2.3'],
     package_data={'numpydoc': ['tests/test_*.py']},
     test_suite = 'nose.collector',
     cmdclass={"sdist": sdist},


### PR DESCRIPTION
In scikit-learn, we would like to start tracking the upstream numpydoc (https://github.com/scikit-learn/scikit-learn/pull/7355). However, we currently render Attributes closely after Parameters, due to their significance, etc. Numpydoc renders Attributes after examples, notes, references, etc. which we find unideal.

This patch allows us to add `templates/numpydoc_doscstring.rst` containing:
```
{{index}}
{{summary}}
{{extended_summary}}
{{parameters}}
{{returns}}
{{yields}}
{{other_parameters}}
{{attributes}}
{{raises}}
{{warns}}
{{warnings}}
{{see_also}}
{{notes}}
{{references}}
{{examples}}
{{methods}}
```
to achieve the sought reordering. It is clearly also much more flexible than that, but I do not have (many) grand designs as yet.