### PR TITLE
TST: run test suite after installing via sdist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,8 @@ before_install:
   - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
   - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --trusted-host wheels.astropy.org --trusted-host wheels2.astropy.org --use-wheel nose numpy matplotlib ${SPHINX_SPEC}
 script:
-  - python setup.py test
+  - |
+    python setup.py sdist
+    cd dist
+    pip install numpydoc* -v
+  - nosetests numpydoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: python
 sudo: false
 python:
-  - 3.5
+  - 3.6
   - 2.7
 env:
   - SPHINX_SPEC="Sphinx==1.2.3"


### PR DESCRIPTION
This should catch issues like the one fixed in gh-83.
``python setup.py test`` should not be used, it's bad practice.