### PR TITLE
BUG: Make docscrape ParseError Python 3 compatible.

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -91,7 +91,7 @@ class Reader(object):
 
 class ParseError(Exception):
     def __str__(self):
-        message = self.message
+        message = self.args[0]
         if hasattr(self, 'docstring'):
             message = "%s in %r" % (message, self.docstring)
         return message

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -6,7 +6,12 @@ import io
 
 import jinja2
 
-from numpydoc.docscrape import NumpyDocString, FunctionDoc, ClassDoc
+from numpydoc.docscrape import (
+    NumpyDocString,
+    FunctionDoc,
+    ClassDoc,
+    ParseError
+)
 from numpydoc.docscrape_sphinx import SphinxDocString, SphinxClassDoc
 from nose.tools import *
 
@@ -634,6 +639,23 @@ def test_see_also():
             assert desc == ['some other func over', 'multiple lines']
         elif func == 'class_j':
             assert desc == ['fubar', 'foobar']
+
+
+def test_see_also_parse_error():
+    text = (
+    """
+    z(x,theta)
+
+    See Also
+    --------
+    :func:`~foo`
+    """)
+    with assert_raises(ParseError) as err:
+        NumpyDocString(text)
+    assert_equal(
+        str(r":func:`~foo` is not a item name in '\n    z(x,theta)\n\n    See Also\n    --------\n    :func:`~foo`\n    '"),
+        str(err.exception)
+    )
 
 def test_see_also_print():
     class Dummy(object):


### PR DESCRIPTION
Fix `__str__` for `ParseError` in Python 3, which was resulting in error
messages with `numpydoc.docscrape.ParseError: <unprintable ParseError object>`
instead of the intended descriptive message.

Use `args[0]` instead of `Exception`'s `message` member, which had been removed
in Python 3. `args` is available to both Python 2 and 3. The `__str__` method
had been failing on an `AttributeError` when using `self.message`, resulting in
an unprintable Exception, which occluded the offending typo in a function name
which triggered the`ParseError`.