### PR TITLE
Fix regression in #81

### DIFF
--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -137,9 +137,6 @@ class SphinxDocString(NumpyDocString):
                     others.append((param, param_type, desc))
 
             if autosum:
-                out += ['.. currentmodule:: '
-                        + self._obj.__module__ + '.' + self._obj.__name__]
-                out += []
                 out += ['.. autosummary::']
                 if self.class_members_toctree:
                     out += ['   :toctree:']

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -904,8 +904,6 @@ def test_class_members_doc_sphinx():
 
     .. rubric:: Attributes
 
-    .. currentmodule:: test_docscrape.Foo
-
     .. autosummary::
        :toctree:
 


### PR DESCRIPTION
It seems #81 introduced some kind of bug:

I have the following rst file documenting MyClass object from ottemplate module:
```
User manual
===========

Reference
---------

.. currentmodule:: ottemplate

.. autosummary::
    :toctree: _generated/
    :template: class.rst_t

    MyClass
```

with class.rst_t:
```
{{ objname }}
{{ underline }}

.. currentmodule:: {{ module }}

.. autoclass:: {{ objname }}

   {% block methods %}
   .. automethod:: __init__
   {% endblock %}

```
results in the following error:
```
following exception was raised:
Traceback (most recent call last):
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/ext/autodoc.py", line 551, in import_object
    __import__(self.modname)
ImportError: No module named 'ottemplate.ottemplate.MyClass'; 'ottemplate.ottemplate' is not a package

```
I use sphinx  latest stable 1.5.5 with python 3.5.2.

What do you think @SirNO ?