### PR TITLE
add context to signature mangling errors

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -331,9 +331,19 @@ class NumpyDocString(collections.Mapping):
                 section = (s.capitalize() for s in section.split(' '))
                 section = ' '.join(section)
                 if self.get(section):
-                    msg = ("The section %s appears twice in the docstring." %
-                           section)
-                    raise ValueError(msg)
+                    if hasattr(self, '_obj'):
+                        # we know where the docs came from:
+                        try:
+                            filename = inspect.getsourcefile(self._obj)
+                        except TypeError:
+                            filename = None
+                        msg = ("The section %s appears twice in "
+                               "the docstring of %s in %s." %
+                               (section, self._obj, filename))
+                        raise ValueError(msg)
+                    else:
+                        msg = ("The section %s appears twice" % section)
+                        raise ValueError(msg)
 
             if section in ('Parameters', 'Returns', 'Yields', 'Raises',
                            'Warns', 'Other Parameters', 'Attributes',

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -113,8 +113,11 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
     if not hasattr(obj, '__doc__'):
         return
-
-    doc = SphinxDocString(pydoc.getdoc(obj))
+    try:
+        doc = SphinxDocString(pydoc.getdoc(obj))
+    except ValueError as e:
+        filename = obj.__code__.co_filename
+        raise ValueError(str(e) + " in {}:{}".format(filename, name))
     sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
     if sig:
         sig = re.sub(sixu("^[^(]*"), sixu(""), sig)

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -113,14 +113,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
     if not hasattr(obj, '__doc__'):
         return
-    try:
-        doc = SphinxDocString(pydoc.getdoc(obj))
-    except ValueError as e:
-        try:
-            filename = inspect.getsourcefile(obj)
-        except TypeError:
-            filename = None
-        raise ValueError(str(e) + " in {}:{}".format(filename, name))
+    doc = SphinxDocString(pydoc.getdoc(obj))
     sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
     if sig:
         sig = re.sub(sixu("^[^(]*"), sixu(""), sig)

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -116,7 +116,10 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
     try:
         doc = SphinxDocString(pydoc.getdoc(obj))
     except ValueError as e:
-        filename = obj.__code__.co_filename
+        try:
+            filename = inspect.getsourcefile(obj)
+        except TypeError:
+            filename = None
         raise ValueError(str(e) + " in {}:{}".format(filename, name))
     sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
     if sig:

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -272,12 +272,16 @@ That should break...
     try:
         SphinxClassDoc(Dummy)
     except ValueError as e:
-        assert_true("test_section_twice.<locals>.Dummy" in str(e))
+        # python 3 version or python 2 version
+        assert_true("test_section_twice.<locals>.Dummy" in str(e)
+                    or 'test_docscrape.Dummy' in str(e))
 
     try:
         SphinxFunctionDoc(dummy_func)
     except ValueError as e:
-        assert_true("test_section_twice.<locals>.dummy_func" in str(e))
+        # python 3 version or python 2 version
+        assert_true("test_section_twice.<locals>.dummy_func" in str(e)
+                    or 'function dummy_func' in str(e))
 
 
 def test_notes():

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1,8 +1,8 @@
 # -*- encoding:utf-8 -*-
 from __future__ import division, absolute_import, print_function
 
-import sys, textwrap
-import io
+import sys
+import textwrap
 
 import jinja2
 
@@ -12,8 +12,10 @@ from numpydoc.docscrape import (
     ClassDoc,
     ParseError
 )
-from numpydoc.docscrape_sphinx import SphinxDocString, SphinxClassDoc
-from nose.tools import *
+from numpydoc.docscrape_sphinx import (SphinxDocString, SphinxClassDoc,
+                                       SphinxFunctionDoc)
+from nose.tools import (assert_equal, assert_raises, assert_list_equal,
+                        assert_true)
 
 if sys.version_info[0] >= 3:
     sixu = lambda s: s
@@ -231,6 +233,51 @@ Notes
 That should break...
 """
     assert_raises(ValueError, NumpyDocString, doc_text)
+
+    # if we have a numpydoc object, we know where the error came from
+    class Dummy(object):
+        """
+        Dummy class.
+
+        Notes
+        -----
+        First note.
+
+        Notes
+        -----
+        Second note.
+
+        """
+        def spam(self, a, b):
+            """Spam\n\nSpam spam."""
+            pass
+
+        def ham(self, c, d):
+            """Cheese\n\nNo cheese."""
+            pass
+
+    def dummy_func(arg):
+        """
+        Dummy function.
+
+        Notes
+        -----
+        First note.
+
+        Notes
+        -----
+        Second note.
+        """
+
+    try:
+        SphinxClassDoc(Dummy)
+    except ValueError as e:
+        assert_true("test_section_twice.<locals>.Dummy" in str(e))
+
+    try:
+        SphinxFunctionDoc(dummy_func)
+    except ValueError as e:
+        assert_true("test_section_twice.<locals>.dummy_func" in str(e))
 
 
 def test_notes():
@@ -967,6 +1014,8 @@ def test_templated_sections():
             Bbb.
 
     """)
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is slightly hacky (again) but hopefully also useful.
I ran into #67 in scikit-learn, but there was no info whatsoever where this came from. Now it gives the object name and file, so I could actually fix it. Even if #67 gets merged, there is still an error about the having yield and return which would have no context. If that is also removed then this code is not needed any more.
