### PR TITLE
Added config option for auto-detecting plot content in Examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,12 @@ The following options can be set in conf.py:
 - numpydoc_use_plots: bool
 
   Whether to produce ``plot::`` directives for Examples sections that
-  contain ``import matplotlib``.
+  match `numpydoc_plot_examples_re`.
+
+- numpydoc_plot_examples_re : str
+
+  The regular expression used to match Examples sections containing plots.
+  ``'import matplotlib'`` by default.
 
 - numpydoc_show_class_members: bool
 

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -28,6 +28,8 @@ class SphinxDocString(NumpyDocString):
 
     def load_config(self, config):
         self.use_plots = config.get('use_plots', False)
+        self.plot_examples_re = re.compile(
+            config.get('plot_examples_re', 'import matplotlib'))
         self.class_members_toctree = config.get('class_members_toctree', True)
         self.template = config.get('template', None)
         if self.template is None:
@@ -225,8 +227,8 @@ class SphinxDocString(NumpyDocString):
     def _str_examples(self):
         examples_str = "\n".join(self['Examples'])
 
-        if (self.use_plots and 'import matplotlib' in examples_str
-                and 'plot::' not in examples_str):
+        if (self.use_plots and 'plot::' not in examples_str
+                and self.plot_examples_re.search(examples_str)):
             out = []
             out += self._str_header('Examples')
             out += ['.. plot::', '']

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -65,6 +65,7 @@ def rename_references(app, what, name, obj, options, lines,
 def mangle_docstrings(app, what, name, obj, options, lines):
 
     cfg = {'use_plots': app.config.numpydoc_use_plots,
+           'plot_examples_re': app.config.numpydoc_plot_examples_re,
            'show_class_members': app.config.numpydoc_show_class_members,
            'show_inherited_class_members':
            app.config.numpydoc_show_inherited_class_members,
@@ -132,6 +133,8 @@ def setup(app, get_doc_object_=get_doc_object):
     app.connect('autodoc-process-signature', mangle_signature)
     app.add_config_value('numpydoc_edit_link', None, False)
     app.add_config_value('numpydoc_use_plots', None, False)
+    app.add_config_value('numpydoc_plot_examples_re',
+                         'import matplotlib', True)
     app.add_config_value('numpydoc_show_class_members', True, True)
     app.add_config_value('numpydoc_show_inherited_class_members', True, True)
     app.add_config_value('numpydoc_class_members_toctree', True, True)

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -712,6 +712,20 @@ def test_plot_examples():
     """, config=cfg)
     assert str(doc).count('plot::') == 1, str(doc)
 
+    # test alternate plot_examples_re
+    cfg = dict(use_plots=True,
+               plot_examples_re='from matplotlib import pyplot as plt')
+
+    doc = SphinxDocString("""
+    Examples
+    --------
+    >>> from matplotlib import pyplot as plt
+    >>> plt.plot([1,2,3],[4,5,6])
+    >>> plt.show()
+    """, config=cfg)
+    assert 'plot::' in str(doc), str(doc)
+
+
 def test_class_members():
 
     class Dummy(object):


### PR DESCRIPTION
This PR adds a new config option `numpydoc_plot_examples_re` to allow for easy customisation of the required content for inserting plot directives in _Examples_ sections. The default remains `'import matplotlib'`.

For example, if the user code doesn't include a direct matplotlib import, but rather imports `pyplot` as `from matplotlib import pyplot`, currently that wouldn't allow for auto-inserting a plot directive, but with the new parameter, they can tell numpydoc from the `conf.py`:

```python
numpydoc_plot_examples_re = 'from matplotlib import pyplot'
```