### PR TITLE
Format attributes like parameters

### DIFF
--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -107,7 +107,7 @@ class SphinxDocString(NumpyDocString):
                         param_obj = None
                     obj_doc = pydoc.getdoc(param_obj)
 
-                    if param_obj and (obj_doc or not desc):
+                    if param_obj and obj_doc:
                         # Referenced object has a docstring
                         autosum += ["    %s%s" % (autosum_prefix, param)]
                         # TODO: add signature to display as in autosummary
@@ -122,7 +122,8 @@ class SphinxDocString(NumpyDocString):
                             desc = re.split('\n\s*\n', obj_doc.strip(), 1)[0]
                             # XXX: Should this have DOTALL?
                             #      It does not in autosummary
-                            m = re.search(r"^([A-Z].*?\.)(?:\s|$)", desc)
+                            m = re.search(r"^([A-Z].*?\.)(?:\s|$)",
+                                          ' '.join(desc.split()))
                             if m:
                                 desc = m.group(1).strip()
                             else:
@@ -183,7 +184,7 @@ class SphinxDocString(NumpyDocString):
                         or inspect.isgetsetdescriptor(param_obj)):
                     param_obj = None
 
-                if param_obj and (pydoc.getdoc(param_obj) or not desc):
+                if param_obj and pydoc.getdoc(param_obj):
                     # Referenced object has a docstring
                     autosum += ["   %s%s" % (prefix, param)]
                 else:

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -108,6 +108,13 @@ class SphinxDocString(NumpyDocString):
             ``desc``, if ``autosum is None`` or ``param`` is not a class
             attribute, or it will be a summary of the class attribute's
             docstring.
+
+        Notes
+        -----
+        This does not have the autosummary functionality to display a method's
+        signature, and hence is not used to format methods.  It may be
+        complicated to incorporate autosummary's signature mangling, as it
+        relies on Sphinx's plugin mechanism.
         """
         param = param.strip()
         display_param = '**%s**' % param

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -89,7 +89,8 @@ class SphinxDocString(NumpyDocString):
         param : str
             The name of the parameter
         desc : list of str
-            The parameter description as given in the docstring
+            The parameter description as given in the docstring. This is
+            ignored when autosummary logic applies.
         autosum : list or None
             If a list, autosummary-style behaviour will apply for params
             that are attributes of the class and have a docstring.
@@ -152,6 +153,25 @@ class SphinxDocString(NumpyDocString):
         return display_param, desc
 
     def _str_param_list(self, name, fake_autosummary=False):
+        """Generate RST for a listing of parameters or similar
+
+        Parameter names are displayed as bold text, and descriptions
+        are in blockquotes.  Descriptions may therefore contain block
+        markup as well.
+
+        Parameters
+        ----------
+        name : str
+            Section name (e.g. Parameters)
+        fake_autosummary : bool
+            When True, the parameter names may correspond to attributes of the
+            object beign documented, usually ``property`` instances on a class.
+            In this case, names will be linked to fuller descriptions.
+
+        Returns
+        -------
+        rst : list of str
+        """
         out = []
         if self[name]:
             if fake_autosummary:
@@ -170,7 +190,7 @@ class SphinxDocString(NumpyDocString):
                 else:
                     out += self._str_indent([display_param])
                 if desc:
-                    out += ['']
+                    out += ['']  # produces a blockquote, rather than a dt/dd
                     out += self._str_indent(desc, 8)
                 out += ['']
 

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -17,6 +17,8 @@ from numpydoc.docscrape_sphinx import (SphinxDocString, SphinxClassDoc,
 from nose.tools import (assert_equal, assert_raises, assert_list_equal,
                         assert_true)
 
+assert_list_equal.__self__.maxDiff = None
+
 if sys.version_info[0] >= 3:
     sixu = lambda s: s
 else:
@@ -975,17 +977,21 @@ def test_class_members_doc_sphinx():
 
     For usage examples, see `ode`.
 
-    .. rubric:: Attributes
+    :Attributes:
 
-    .. autosummary::
-       :toctree:
+        **t** : float
+            Current time.
+        **y** : ndarray
+            Current variable values.
+        :obj:`x <x>` : float
+            Test attribute
 
-       x
+    ..
+        HACK to make autogen generate docs:
+        .. autosummary::
+            :toctree:
 
-    =====  ==========
-    **t**  (float) Current time.
-    **y**  (ndarray) Current variable values.
-    =====  ==========
+            x
 
     .. rubric:: Methods
 

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -899,8 +899,17 @@ class_doc_txt = """
         Current time.
     y : ndarray
         Current variable values.
-    x : float
-        Some parameter
+
+        * hello
+        * world
+    an_attribute : float
+        The docstring is printed instead
+    no_docstring : str
+        But a description
+    no_docstring2 : str
+    multiline_sentence
+    midword_period
+    no_period
 
     Methods
     -------
@@ -936,8 +945,17 @@ def test_class_members_doc():
         Current time.
     y : ndarray
         Current variable values.
-    x : float
-        Some parameter
+
+        * hello
+        * world
+    an_attribute : float
+        The docstring is printed instead
+    no_docstring : str
+        But a description
+    no_docstring2 : str
+    multiline_sentence
+    midword_period
+    no_period
 
     Methods
     -------
@@ -954,8 +972,36 @@ def test_class_members_doc():
 def test_class_members_doc_sphinx():
     class Foo:
         @property
-        def x(self):
+        def an_attribute(self):
             """Test attribute"""
+            return None
+
+        @property
+        def no_docstring(self):
+            return None
+
+        @property
+        def no_docstring2(self):
+            return None
+
+        @property
+        def multiline_sentence(self):
+            """This is a
+            sentence. It spans multiple lines."""
+            return None
+
+        @property
+        def midword_period(self):
+            """The sentence for numpy.org."""
+            return None
+
+        @property
+        def no_period(self):
+            """This does not have a period
+            so we truncate its summary to the first linebreak
+
+            Apparently.
+            """
             return None
 
     doc = SphinxClassDoc(Foo, class_doc_txt)
@@ -983,15 +1029,30 @@ def test_class_members_doc_sphinx():
             Current time.
         **y** : ndarray
             Current variable values.
-        :obj:`x <x>` : float
+
+            * hello
+            * world
+        :obj:`an_attribute <an_attribute>` : float
             Test attribute
+        **no_docstring** : str
+            But a description
+        **no_docstring2** : str
+        :obj:`multiline_sentence <multiline_sentence>`
+            This is a sentence.
+        :obj:`midword_period <midword_period>`
+            The sentence for numpy.org.
+        :obj:`no_period <no_period>`
+            This does not have a period
 
     ..
         HACK to make autogen generate docs:
         .. autosummary::
             :toctree:
 
-            x
+            an_attribute
+            multiline_sentence
+            midword_period
+            no_period
 
     .. rubric:: Methods
 


### PR DESCRIPTION
Resolves #102.
Resolves #104.
Resolves https://github.com/scikit-learn/scikit-learn/issues/9495

- Provide links to autogen when possible
- Use fake (commented) autosummary nodes (as already used in scipy docs)

I'm a bit confused about how/whether the autosummaries inside numpydoc-munged docstrings work. I'm not quite sure whether this patch is working on scipy docs and would appreciate someone checking. It's good for scikit-learn.