### PR TITLE
Use definition lists rather than blockquotes

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -20,6 +20,10 @@ The following options can be set in your Sphinx ``conf.py``:
 numpydoc_use_plots : bool
   Whether to produce ``plot::`` directives for Examples sections that
   contain ``import matplotlib``.
+numpydoc_use_blockqutoes : bool
+  Until version 0.8, parameter definitions were shown as blockquotes, rather
+  than in a definition list.  If your styling requires blockquotes, switch
+  this config option to True.  This option will be removed in version 0.10.
 numpydoc_show_class_members : bool
   Whether to show all members of a class in the Methods and Attributes
   sections automatically.

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -403,7 +403,8 @@ class NumpyDocString(collections.Mapping):
                     out += ['%s : %s' % (param, param_type)]
                 else:
                     out += [param]
-                out += self._str_indent(desc)
+                if desc and ''.join(desc).strip():
+                    out += self._str_indent(desc)
             out += ['']
         return out
 

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -13,6 +13,15 @@ import copy
 import sys
 
 
+def strip_blank_lines(l):
+    "Remove leading and trailing blank lines from a list of lines"
+    while l and not l[0].strip():
+        del l[0]
+    while l and not l[-1].strip():
+        del l[-1]
+    return l
+
+
 class Reader(object):
     """A line-based string reader.
 
@@ -214,6 +223,7 @@ class NumpyDocString(collections.Mapping):
 
             desc = r.read_to_next_unindented_line()
             desc = dedent_lines(desc)
+            desc = strip_blank_lines(desc)
 
             params.append((arg_name, arg_type, desc))
 

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -28,6 +28,7 @@ class SphinxDocString(NumpyDocString):
 
     def load_config(self, config):
         self.use_plots = config.get('use_plots', False)
+        self.use_blockquotes = config.get('use_blockquotes', False)
         self.class_members_toctree = config.get('class_members_toctree', True)
         self.template = config.get('template', None)
         if self.template is None:
@@ -63,18 +64,26 @@ class SphinxDocString(NumpyDocString):
         return self['Extended Summary'] + ['']
 
     def _str_returns(self, name='Returns'):
+        if self.use_blockquotes:
+            typed_fmt = '**%s** : %s'
+            untyped_fmt = '**%s**'
+        else:
+            typed_fmt = '%s : %s'
+            untyped_fmt = '%s'
+
         out = []
         if self[name]:
             out += self._str_field_list(name)
             out += ['']
             for param, param_type, desc in self[name]:
                 if param_type:
-                    out += self._str_indent(['**%s** : %s' % (param.strip(),
-                                                              param_type)])
+                    out += self._str_indent([typed_fmt % (param.strip(),
+                                                          param_type)])
                 else:
-                    out += self._str_indent([param.strip()])
+                    out += self._str_indent([untyped_fmt % param.strip()])
                 if desc:
-                    out += ['']
+                    if self.use_blockquotes:
+                        out += ['']
                     out += self._str_indent(desc, 8)
                 out += ['']
         return out
@@ -117,7 +126,7 @@ class SphinxDocString(NumpyDocString):
         relies on Sphinx's plugin mechanism.
         """
         param = param.strip()
-        display_param = '**%s**' % param
+        display_param = ('**%s**' if self.use_blockquotes else '%s') % param
 
         if autosum is None:
             return display_param, desc
@@ -197,7 +206,8 @@ class SphinxDocString(NumpyDocString):
                 else:
                     out += self._str_indent([display_param])
                 if desc:
-                    out += ['']  # produces a blockquote, rather than a dt/dd
+                    if self.use_blockquotes:
+                        out += ['']
                     out += self._str_indent(desc, 8)
                 out += ['']
 

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -285,7 +285,6 @@ class SphinxDocString(NumpyDocString):
         out = []
         if self[name]:
             out += self._str_header(name)
-            out += ['']
             content = textwrap.dedent("\n".join(self[name])).split("\n")
             out += content
             out += ['']
@@ -304,6 +303,7 @@ class SphinxDocString(NumpyDocString):
         if self['Warnings']:
             out = ['.. warning::', '']
             out += self._str_indent(self['Warnings'])
+            out += ['']
         return out
 
     def _str_index(self):
@@ -320,6 +320,7 @@ class SphinxDocString(NumpyDocString):
                 out += ['   single: %s' % (', '.join(references))]
             else:
                 out += ['   %s: %s' % (section, ','.join(references))]
+        out += ['']
         return out
 
     def _str_references(self):

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -65,6 +65,7 @@ def rename_references(app, what, name, obj, options, lines,
 def mangle_docstrings(app, what, name, obj, options, lines):
 
     cfg = {'use_plots': app.config.numpydoc_use_plots,
+           'use_blockquotes': app.config.numpydoc_use_blockquotes,
            'show_class_members': app.config.numpydoc_show_class_members,
            'show_inherited_class_members':
            app.config.numpydoc_show_inherited_class_members,
@@ -131,6 +132,7 @@ def setup(app, get_doc_object_=get_doc_object):
     app.connect('autodoc-process-signature', mangle_signature)
     app.add_config_value('numpydoc_edit_link', None, False)
     app.add_config_value('numpydoc_use_plots', None, False)
+    app.add_config_value('numpydoc_use_blockquotes', None, False)
     app.add_config_value('numpydoc_show_class_members', True, True)
     app.add_config_value('numpydoc_show_inherited_class_members', True, True)
     app.add_config_value('numpydoc_class_members_toctree', True, True)

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -842,6 +842,46 @@ def test_plot_examples():
     assert str(doc).count('plot::') == 1, str(doc)
 
 
+def test_use_blockquotes():
+    cfg = dict(use_blockquotes=True)
+    doc = SphinxDocString("""
+    Parameters
+    ----------
+    abc : def
+        ghi
+    jkl
+        mno
+
+    Returns
+    -------
+    ABC : DEF
+        GHI
+    JKL
+        MNO
+    """, config=cfg)
+    line_by_line_compare(str(doc), '''
+    :Parameters:
+
+        **abc** : def
+
+            ghi
+
+        **jkl**
+
+            mno
+
+    :Returns:
+
+        **ABC** : DEF
+
+            GHI
+
+        **JKL**
+
+            MNO
+    ''')
+
+
 def test_class_members():
 
     class Dummy(object):

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1,6 +1,7 @@
 # -*- encoding:utf-8 -*-
 from __future__ import division, absolute_import, print_function
 
+import re
 import sys
 import textwrap
 import warnings
@@ -316,11 +317,19 @@ def test_index():
     assert_equal(len(doc['index']['refguide']), 2)
 
 
-def non_blank_line_by_line_compare(a, b):
+def _strip_blank_lines(s):
+    "Remove leading, trailing and multiple blank lines"
+    s = re.sub(r'^\s*\n', '', s)
+    s = re.sub(r'\n\s*$', '', s)
+    s = re.sub(r'\n\s*\n', r'\n\n', s)
+    return s
+
+
+def line_by_line_compare(a, b):
     a = textwrap.dedent(a)
     b = textwrap.dedent(b)
-    a = [l.rstrip() for l in a.split('\n') if l.strip()]
-    b = [l.rstrip() for l in b.split('\n') if l.strip()]
+    a = [l.rstrip() for l in _strip_blank_lines(a).split('\n')]
+    b = [l.rstrip() for l in _strip_blank_lines(b).split('\n')]
     assert_list_equal(a, b)
 
 
@@ -328,7 +337,7 @@ def test_str():
     # doc_txt has the order of Notes and See Also sections flipped.
     # This should be handled automatically, and so, one thing this test does
     # is to make sure that See Also precedes Notes in the output.
-    non_blank_line_by_line_compare(str(doc),
+    line_by_line_compare(str(doc),
 """numpy.multivariate_normal(mean, cov, shape=None, spam=None)
 
 Draw values from a multivariate normal distribution with specified
@@ -387,6 +396,7 @@ Certain warnings apply.
 
 See Also
 --------
+
 `some`_, `other`_, `funcs`_
 
 `otherfunc`_
@@ -438,7 +448,7 @@ standard deviation:
 
 
 def test_yield_str():
-    non_blank_line_by_line_compare(str(doc_yields),
+    line_by_line_compare(str(doc_yields),
 """Test generator
 
 Yields
@@ -455,7 +465,7 @@ int
 
 def test_sphinx_str():
     sphinx_doc = SphinxDocString(doc_txt)
-    non_blank_line_by_line_compare(str(sphinx_doc),
+    line_by_line_compare(str(sphinx_doc),
 """
 .. index:: random
    single: random;distributions, random;gauss
@@ -572,7 +582,7 @@ standard deviation:
 
 def test_sphinx_yields_str():
     sphinx_doc = SphinxDocString(doc_yields_txt)
-    non_blank_line_by_line_compare(str(sphinx_doc),
+    line_by_line_compare(str(sphinx_doc),
 """Test generator
 
 :Yields:
@@ -972,7 +982,7 @@ class_doc_txt = """
 
 def test_class_members_doc():
     doc = ClassDoc(None, class_doc_txt)
-    non_blank_line_by_line_compare(str(doc),
+    line_by_line_compare(str(doc),
     """
     Foo
 
@@ -1008,9 +1018,7 @@ def test_class_members_doc():
     Methods
     -------
     a
-
     b
-
     c
 
     .. index::
@@ -1054,7 +1062,7 @@ def test_class_members_doc_sphinx():
             return None
 
     doc = SphinxClassDoc(Foo, class_doc_txt)
-    non_blank_line_by_line_compare(str(doc),
+    line_by_line_compare(str(doc),
     """
     Foo
 
@@ -1072,22 +1080,29 @@ def test_class_members_doc_sphinx():
 
     :Attributes:
 
-        **t** : float
+        t : float
             Current time.
-        **y** : ndarray
+
+        y : ndarray
             Current variable values.
 
             * hello
             * world
+
         :obj:`an_attribute <an_attribute>` : float
             Test attribute
-        **no_docstring** : str
+
+        no_docstring : str
             But a description
-        **no_docstring2** : str
+
+        no_docstring2 : str
+
         :obj:`multiline_sentence <multiline_sentence>`
             This is a sentence.
+
         :obj:`midword_period <midword_period>`
             The sentence for numpy.org.
+
         :obj:`no_period <no_period>`
             This does not have a period
 
@@ -1095,7 +1110,6 @@ def test_class_members_doc_sphinx():
         HACK to make autogen generate docs:
         .. autosummary::
             :toctree:
-
             an_attribute
             multiline_sentence
             midword_period
@@ -1114,13 +1128,12 @@ def test_class_members_doc_sphinx():
 
 def test_templated_sections():
     doc = SphinxClassDoc(None, class_doc_txt,
-                         config={'template': jinja2.Template('{{examples}}{{parameters}}')})
-    non_blank_line_by_line_compare(str(doc),
+                         config={'template': jinja2.Template('{{examples}}\n{{parameters}}')})
+    line_by_line_compare(str(doc),
     """
     .. rubric:: Examples
 
     For usage examples, see `ode`.
-
 
     :Parameters:
 

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -468,28 +468,24 @@ of the one-dimensional normal distribution to higher dimensions.
 
 :Parameters:
 
-    **mean** : (N,) ndarray
-
+    mean : (N,) ndarray
         Mean of the N-dimensional distribution.
 
         .. math::
 
            (1+2+3)/3
 
-    **cov** : (N, N) ndarray
-
+    cov : (N, N) ndarray
         Covariance matrix of the distribution.
 
-    **shape** : tuple of ints
-
+    shape : tuple of ints
         Given a shape of, for example, (m,n,k), m*n*k samples are
         generated, and packed in an m-by-n-by-k arrangement.  Because
         each sample is N-dimensional, the output shape is (m,n,k,N).
 
 :Returns:
 
-    **out** : ndarray
-
+    out : ndarray
         The drawn samples, arranged according to `shape`.  If the
         shape given is (m,n,...), then the shape of `out` is is
         (m,n,...,N).
@@ -498,26 +494,22 @@ of the one-dimensional normal distribution to higher dimensions.
         value drawn from the distribution.
 
     list of str
-
         This is not a real return value.  It exists to test
         anonymous return values.
 
 :Other Parameters:
 
-    **spam** : parrot
-
+    spam : parrot
         A parrot off its mortal coil.
 
 :Raises:
 
-    **RuntimeError**
-
+    RuntimeError
         Some error
 
 :Warns:
 
-    **RuntimeWarning**
-
+    RuntimeWarning
         Some warning
 
 .. warning::
@@ -585,16 +577,13 @@ def test_sphinx_yields_str():
 
 :Yields:
 
-    **a** : int
-
+    a : int
         The number of apples.
 
-    **b** : int
-
+    b : int
         The number of bananas.
 
     int
-
         The number of unknowns.
 """)
 
@@ -1071,12 +1060,10 @@ def test_class_members_doc_sphinx():
 
     :Parameters:
 
-        **f** : callable ``f(t, y, *f_args)``
-
+        f : callable ``f(t, y, *f_args)``
             Aaa.
 
-        **jac** : callable ``jac(t, y, *jac_args)``
-
+        jac : callable ``jac(t, y, *jac_args)``
             Bbb.
 
     .. rubric:: Examples
@@ -1137,12 +1124,10 @@ def test_templated_sections():
 
     :Parameters:
 
-        **f** : callable ``f(t, y, *f_args)``
-
+        f : callable ``f(t, y, *f_args)``
             Aaa.
 
-        **jac** : callable ``jac(t, y, *jac_args)``
-
+        jac : callable ``jac(t, y, *jac_args)``
             Bbb.
 
     """)

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -172,7 +172,7 @@ def test_parameters():
     arg, arg_type, desc = doc['Parameters'][1]
     assert_equal(arg_type, '(N, N) ndarray')
     assert desc[0].startswith('Covariance matrix')
-    assert doc['Parameters'][0][-1][-2] == '   (1+2+3)/3'
+    assert doc['Parameters'][0][-1][-1] == '   (1+2+3)/3'
 
 
 def test_other_parameters():
@@ -354,7 +354,6 @@ mean : (N,) ndarray
     .. math::
 
        (1+2+3)/3
-
 cov : (N, N) ndarray
     Covariance matrix of the distribution.
 shape : tuple of ints
@@ -948,6 +947,7 @@ class_doc_txt = """
     f : callable ``f(t, y, *f_args)``
         Aaa.
     jac : callable ``jac(t, y, *jac_args)``
+
         Bbb.
 
     Attributes


### PR DESCRIPTION
This probably falls under the category of "if it ain't broke, don't fix it", but I note that we're strangely using blockquotes for parameter listings instead of definition lists. UPDATED: now this PR proposes to use definition lists by default, with a switch to use the legacy blockquotes.

From [RST docs](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#definition-lists):

> A definition is a block indented relative to the term, and may contain multiple paragraphs and other body elements. **There may be no blank line between a term line and a definition block (this distinguishes definition lists from block quotes).**

(emphasis mine)

As shown in the screenshots below, there are formatting differences in the default stylesheets:
* definition lists have more semantic HTML markup
* parameter names are bolded in definition lists; we currently mark them up explicitly in numpydoc
* type specs fill the place of classifiers in the RST spec, and are formatted with bold and italics
    * the `:` has the class `classifier-delimiter` and what follows has the class `classifier`
* the definition (i.e. parameter description) has smaller margins on all sides, meaning the parameter listing is much more compact, and the description has more visual affinity with the parameter it describes.

definition lists (with this patch):
![definition lists (with this patch)](https://user-images.githubusercontent.com/78827/30088186-27f69f1a-92e8-11e7-934a-f209b5d8d61c.png)

blockquotes (at master)
![blockquotes (at master)](https://user-images.githubusercontent.com/78827/30088208-3c4df24c-92e8-11e7-935c-106a1772e26d.png)

Does anyone know of disadvantages to definition lists, or why they have not been used here?

This patch should probably be extended to ensure that the first line of a parameter description is *not* blank, or it will revert to the blockquote styling.

This also highlights a problem with numpydoc's tests: vertical whitespace is significant in RST, particularly its presence/absence, but tests currently ignore blank lines, which is a Bad Idea.