### PR TITLE
Allow see also object ref to incorporate ~ prefix

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -213,7 +213,8 @@ class NumpyDocString(collections.Mapping):
 
         return params
 
-    _name_rgx = re.compile(r"^\s*(:(?P<role>\w+):`(?P<name>[a-zA-Z0-9_.-]+)`|"
+    _name_rgx = re.compile(r"^\s*(:(?P<role>\w+):"
+                           r"`(?P<name>(?:~\w+\.)?[a-zA-Z0-9_.-]+)`|"
                            r" (?P<name2>[a-zA-Z0-9_.-]+))\s*", re.X)
 
     def _parse_see_also(self, content):

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -665,21 +665,23 @@ def test_see_also():
     func_f, func_g, :meth:`func_h`, func_j,
     func_k
     :obj:`baz.obj_q`
+    :obj:`~baz.obj_r`
     :class:`class_j`: fubar
         foobar
     """)
 
-    assert len(doc6['See Also']) == 12
+    assert len(doc6['See Also']) == 13
     for func, desc, role in doc6['See Also']:
         if func in ('func_a', 'func_b', 'func_c', 'func_f',
-                    'func_g', 'func_h', 'func_j', 'func_k', 'baz.obj_q'):
+                    'func_g', 'func_h', 'func_j', 'func_k', 'baz.obj_q',
+                    '~baz.obj_r'):
             assert(not desc)
         else:
             assert(desc)
 
         if func == 'func_h':
             assert role == 'meth'
-        elif func == 'baz.obj_q':
+        elif func == 'baz.obj_q' or func == '~baz.obj_r':
             assert role == 'obj'
         elif func == 'class_j':
             assert role == 'class'


### PR DESCRIPTION
Fixes #3

Because it's been open too long and is easy to fix.