### PR TITLE
Adding object infos to be able to raise meaningful location info

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -124,7 +124,7 @@ class NumpyDocString(collections.Mapping):
         'index': {}
     }
 
-    def __init__(self, docstring, obj_info, config={}):
+    def __init__(self, docstring, config={}, obj_info=(None, None)):
         orig_docstring = docstring
         docstring = textwrap.dedent(docstring).split('\n')
 
@@ -492,7 +492,7 @@ class FunctionDoc(NumpyDocString):
 
         module = getattr(func, '__module__', None)
         qualname = getattr(func, '__qualname__', funcname)
-        NumpyDocString.__init__(self, doc, (module, qualname))
+        NumpyDocString.__init__(self, doc, obj_info=(module, qualname))
 
         if not self['Signature'] and func is not None:
             func, func_name = self.get_func()
@@ -562,7 +562,7 @@ class ClassDoc(NumpyDocString):
 
         module = getattr(cls, '__module__', None)
         qualname = getattr(cls, '__qualname__', modulename)
-        NumpyDocString.__init__(self, doc, (module, qualname))
+        NumpyDocString.__init__(self, doc, obj_info=(module, qualname))
 
         if config.get('show_class_members', True):
             def splitlines_x(s):

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -22,8 +22,9 @@ else:
 
 
 class SphinxDocString(NumpyDocString):
-    def __init__(self, docstring, obj_info, config={}):
-        NumpyDocString.__init__(self, docstring, obj_info, config=config)
+    def __init__(self, docstring, config={}, obj_info=(None, None)):
+        NumpyDocString.__init__(self, docstring, config=config,
+                                obj_info=obj_info)
         self.load_config(config)
 
     def load_config(self, config):
@@ -245,7 +246,7 @@ class SphinxDocString(NumpyDocString):
                         or inspect.isgetsetdescriptor(param_obj)):
                     param_obj = None
 
-                if param_obj and (pydoc.getdoc(param_obj) or not desc):
+                if param_obj and pydoc.getdoc(param_obj):
                     # Referenced object has a docstring
                     autosum += ["   %s%s" % (prefix, param)]
                 else:
@@ -395,7 +396,8 @@ class SphinxObjDoc(SphinxDocString):
         self.load_config(config)
         module = getattr(obj, '__module__', None)
         qualname = getattr(obj, '__qualname__', name)
-        SphinxDocString.__init__(self, doc, (module, qualname), config=config)
+        SphinxDocString.__init__(self, doc, config=config,
+                                 obj_info=(module, qualname))
 
 
 def get_doc_object(obj, what=None, doc=None, config={}, builder=None, name=None):

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -78,7 +78,7 @@ def mangle_docstrings(app, what, name, obj, options, lines):
         lines[:] = title_re.sub(sixu(''), u_NL.join(lines)).split(u_NL)
     else:
         doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg,
-                             builder=app.builder)
+                             builder=app.builder, name=name)
         if sys.version_info[0] >= 3:
             doc = str(doc)
         else:
@@ -113,7 +113,10 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
     if not hasattr(obj, '__doc__'):
         return
-    doc = SphinxDocString(pydoc.getdoc(obj))
+
+    module = getattr(obj, '__module__', None)
+    qualname = getattr(obj, '__qualname__', name)
+    doc = SphinxDocString(pydoc.getdoc(obj), (module, qualname))
     sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
     if sig:
         sig = re.sub(sixu("^[^(]*"), sixu(""), sig)

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -116,7 +116,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
     module = getattr(obj, '__module__', None)
     qualname = getattr(obj, '__qualname__', name)
-    doc = SphinxDocString(pydoc.getdoc(obj), (module, qualname))
+    doc = SphinxDocString(pydoc.getdoc(obj), obj_info=(module, qualname))
     sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
     if sig:
         sig = re.sub(sixu("^[^(]*"), sixu(""), sig)


### PR DESCRIPTION
Fixes #115.

The example below has an invalid ``Return`` section in one of the doctrings, and in another one a duplicate ``Examples`` section. The invalid ``Return`` section is still warned over twice, but I take it as an improvement compared to the original 4 times.

I still need to add tests, and probably fix currently failing ones, but would first like to get the opinions whether you like this approach or not.

With master
```
updating environment: 176 added, 0 changed, 0 removed
/Users/kgabor/bsipocz/devel/astroquery/astropy_helpers/astropy_helpers/extern/numpydoc/docscrape.py:366: UserWarning: Unknown section Return in the docstring of None in None.
  warn(msg)
/Users/kgabor/bsipocz/devel/astroquery/astropy_helpers/astropy_helpers/extern/numpydoc/docscrape.py:366: UserWarning: Unknown section Return in the docstring of <function ExoplanetOrbitDatabaseClass.get_table at 0x108f7f0d0> in /Users/kgabor/bsipocz/devel/astroquery/build/lib.macosx-10.10-x86_64-3.5/astroquery/exoplanet_orbit_database/exoplanet_orbit_database.py.
  warn(msg)
/Users/kgabor/bsipocz/devel/astroquery/astropy_helpers/astropy_helpers/extern/numpydoc/docscrape.py:366: UserWarning: Unknown section Return in the docstring of None in None.
  warn(msg)
/Users/kgabor/bsipocz/devel/astroquery/astropy_helpers/astropy_helpers/extern/numpydoc/docscrape.py:366: UserWarning: Unknown section Return in the docstring of <function ExoplanetOrbitDatabaseClass.get_table at 0x108f7f0d0> in /Users/kgabor/bsipocz/devel/astroquery/build/lib.macosx-10.10-x86_64-3.5/astroquery/exoplanet_orbit_database/exoplanet_orbit_database.py.
  warn(msg)
reading sources... [ 44%] api/astroquery.skyview.SkyViewClass                  o_dictlass
Exception occurred:
  File "/Users/kgabor/bsipocz/devel/astroquery/astropy_helpers/astropy_helpers/extern/numpydoc/docscrape.py", line 364, in _error_location
    raise ValueError(msg)
ValueError: The section Examples appears twice in the docstring of None in None.
The full traceback has been saved in /var/folders/8j/hn5sncjs31143t3kq4zxtg680000gn/T/sphinx-err-_hmijs60.log, if you want to report the issue to the developers.
```

With this PR:
```
updating environment: 176 added, 0 changed, 0 removed
/Users/kgabor/bsipocz/devel/astroquery/astropy_helpers/astropy_helpers/extern/numpydoc/docscrape.py:360: UserWarning: Unknown section Return in the docstring of ExoplanetOrbitDatabaseClass.get_table in astroquery.exoplanet_orbit_database.exoplanet_orbit_database.
  warn(msg)
/Users/kgabor/bsipocz/devel/astroquery/astropy_helpers/astropy_helpers/extern/numpydoc/docscrape.py:360: UserWarning: Unknown section Return in the docstring of ExoplanetOrbitDatabaseClass.get_table in astroquery.exoplanet_orbit_database.exoplanet_orbit_database.
  warn(msg)
reading sources... [ 44%] api/astroquery.skyview.SkyViewClass                  o_dictlass
Exception occurred:
  File "/Users/kgabor/bsipocz/devel/astroquery/astropy_helpers/astropy_helpers/extern/numpydoc/docscrape.py", line 358, in _error_location
    raise ValueError(msg)
ValueError: The section Examples appears twice in the docstring of SkyViewClass.get_image_list in astroquery.skyview.core.
The full traceback has been saved in /var/folders/8j/hn5sncjs31143t3kq4zxtg680000gn/T/sphinx-err-a5gjyi1g.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
```