### PR TITLE
Support 'from matplotlib import' as alias for 'import matplotlib'

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -19,7 +19,7 @@ The following options can be set in your Sphinx ``conf.py``:
 
 numpydoc_use_plots : bool
   Whether to produce ``plot::`` directives for Examples sections that
-  contain ``import matplotlib``.
+  contain ``import matplotlib`` or ``from matplotlib import``.
 numpydoc_show_class_members : bool
   Whether to show all members of a class in the Methods and Attributes
   sections automatically.

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -21,6 +21,9 @@ else:
     sixu = lambda s: unicode(s, 'unicode_escape')
 
 
+IMPORT_MATPLOTLIB_RE = r'\b(import +matplotlib|from +matplotlib +import)\b'
+
+
 class SphinxDocString(NumpyDocString):
     def __init__(self, docstring, config={}):
         NumpyDocString.__init__(self, docstring, config=config)
@@ -337,7 +340,7 @@ class SphinxDocString(NumpyDocString):
     def _str_examples(self):
         examples_str = "\n".join(self['Examples'])
 
-        if (self.use_plots and 'import matplotlib' in examples_str
+        if (self.use_plots and IMPORT_MATPLOTLIB_RE.search(examples_str)
                 and 'plot::' not in examples_str):
             out = []
             out += self._str_header('Examples')

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -340,7 +340,7 @@ class SphinxDocString(NumpyDocString):
     def _str_examples(self):
         examples_str = "\n".join(self['Examples'])
 
-        if (self.use_plots and IMPORT_MATPLOTLIB_RE.search(examples_str)
+        if (self.use_plots and re.search(IMPORT_MATPLOTLIB_RE, examples_str)
                 and 'plot::' not in examples_str):
             out = []
             out += self._str_header('Examples')

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -835,6 +835,15 @@ def test_plot_examples():
     doc = SphinxDocString("""
     Examples
     --------
+    >>> from matplotlib import pyplot as plt
+    >>> plt.plot([1,2,3],[4,5,6])
+    >>> plt.show()
+    """, config=cfg)
+    assert 'plot::' in str(doc), str(doc)
+
+    doc = SphinxDocString("""
+    Examples
+    --------
     .. plot::
 
        import matplotlib.pyplot as plt


### PR DESCRIPTION
Closes #96