### PR TITLE
Ensure reference renaming is parallel-safe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   directories:
     - $HOME/.cache/pip
 before_install:
-  - sudo apt-get install texlive texlive-latex-extra
+  - sudo apt-get install texlive texlive-latex-extra latexmk
   - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
   - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --trusted-host wheels.astropy.org --trusted-host wheels2.astropy.org --use-wheel nose numpy matplotlib ${SPHINX_SPEC}
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   directories:
     - $HOME/.cache/pip
 before_install:
-  - sudo apt-get install texlive-latex-base
+  - sudo apt-get install texlive texlive-latex-extra
   - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
   - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --trusted-host wheels.astropy.org --trusted-host wheels2.astropy.org --use-wheel nose numpy matplotlib ${SPHINX_SPEC}
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
   directories:
     - $HOME/.cache/pip
 before_install:
+  - sudo apt-get install texlive-latex-base
   - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
   - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --trusted-host wheels.astropy.org --trusted-host wheels2.astropy.org --use-wheel nose numpy matplotlib ${SPHINX_SPEC}
 script:

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -373,6 +373,12 @@ The sections of the docstring are:
     should not be required to understand it.  References are numbered, starting
     from one, in the order in which they are cited.
 
+    .. warning:: **References will break tables**
+
+        Where references like [1] appear in a tables within a numpydoc
+        docstring, the table markup will be broken by numpydoc processing.  See
+        `numpydoc issue #130 <https://github.com/numpy/numpydoc/issues/130>`_
+
 12. **Examples**
 
     An optional section for examples, using the `doctest

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -27,7 +27,7 @@ import hashlib
 
 from docutils.nodes import citation, Text
 import sphinx
-from sphinx.addnodes import pending_xref, desc
+from sphinx.addnodes import pending_xref, desc_content
 
 if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
@@ -70,7 +70,7 @@ def rename_references(app, what, name, obj, options, lines):
 
 
 def _ascend(node, cls):
-    while not isinstance(node, cls) and node.parent:
+    while node and not isinstance(node, cls):
         node = node.parent
     return node
 
@@ -78,7 +78,7 @@ def _ascend(node, cls):
 def relabel_references(app, doc):
     # Change 'hash-ref' to 'ref' in label text
     for citation_node in doc.traverse(citation):
-        if _ascend(citation_node, desc) is None:
+        if _ascend(citation_node, desc_content) is None:
             # no desc node in ancestry -> not in a docstring
             # XXX: should we also somehow check it's in a References section?
             continue

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -21,10 +21,13 @@ from __future__ import division, absolute_import, print_function
 import sys
 import re
 import pydoc
-import sphinx
 import inspect
 import collections
 import hashlib
+
+from docutils.nodes import citation, Text
+import sphinx
+from sphinx.addnodes import pending_xref
 
 if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
@@ -65,8 +68,6 @@ def rename_references(app, what, name, obj, options, lines):
 
 def relabel_references(app, doc):
     # Change name_ref to ref in label text
-    from docutils.nodes import citation, Text
-    from sphinx.addnodes import pending_xref
     for citation_node in doc.traverse(citation):
         label_node = citation_node[0]
         new_text = Text(citation_node['names'][0].split('-')[-1])

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -81,7 +81,7 @@ def relabel_references(app, doc):
                 return (isinstance(node, pending_xref) and
                         node[0].astext() == '[%s]' % ref_text)
 
-            for xref_node in ref.parent.traverse():
+            for xref_node in ref.parent.traverse(matching_pending_xref):
                 xref_node.replace(xref_node[0], Text('[%s]' % new_text))
             ref.replace(ref_text, new_text.copy())
 

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -67,7 +67,7 @@ def rename_references(app, what, name, obj, options, lines):
 
 
 def relabel_references(app, doc):
-    # Change name_ref to ref in label text
+    # Change 'hash-ref' to 'ref' in label text
     for citation_node in doc.traverse(citation):
         label_node = citation_node[0]
         new_text = Text(citation_node['names'][0].split('-')[-1])


### PR DESCRIPTION
Fixes #112. Builds upon #135. Makes #130 (breaking table whitespace) worse, but see below.

Also fixes #114

At autodoc-process-docstring time, this prefixes each reference with a token indicative of which docstring it belongs to and then relabels the text of the reference in the doctree once the reST is parsed. The rendered reference naming therefore reflects what was in the original reST, rather than something with prefixes etc. So you get [1] rather than [R1].

I'm not sure how to rigorously test this but will post some images soon.

The issue of breaking table whitespace (#130) is more minor than #112. It is exacerbated by this patch since references become much longer. There may be a more ideal solution that involves post-processing the doctrees to do *all* of the reference renaming (i.e. without this decorate-and-undecorate approach), but when I tried to implement it, I realised it would involve hacking footnotes to become citations, handling initial broken resolutions (incl `docutils.nodes.problematic`), and other madness. It may come later. In the meantime I think we should just tell users that citations cannot be used in tables.