### PR TITLE
Handle case where description is empty

### DIFF
--- a/doc/example.py
+++ b/doc/example.py
@@ -62,6 +62,7 @@ def foo(var1, var2, long_var_name='hi'):
         Explanation of return value named `describe`.
     out : type
         Explanation of `out`.
+    type_without_description
 
     Other Parameters
     ----------------

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -200,10 +200,12 @@ class SphinxDocString(NumpyDocString):
                                                           param_type)])
                 else:
                     out += self._str_indent([display_param])
-                if desc:
-                    if self.use_blockquotes:
-                        out += ['']
-                    out += self._str_indent(desc, 8)
+                if desc and self.use_blockquotes:
+                    out += ['']
+                elif not desc:
+                    # empty definition
+                    desc = ['..']
+                out += self._str_indent(desc, 8)
                 out += ['']
 
         return out

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1147,6 +1147,7 @@ def test_class_members_doc_sphinx():
             But a description
 
         no_docstring2 : str
+            ..
 
         :obj:`multiline_sentence <multiline_sentence>`
             This is a sentence.


### PR DESCRIPTION
Use a reST comment instead of a definition

Fixes a bug introduced in #107 
