### PR TITLE
Escape the * in *args and **kwargs

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -199,14 +199,6 @@ class NumpyDocString(collections.Mapping):
 
         return section
 
-    def _escape_args_and_kwargs(self, name):
-        if name[:2] == '**':
-            return r'\*\*' + name[2:]
-        elif name[:1] == '*':
-            return r'\*' + name[1:]
-        else:
-            return name
-
     def _read_sections(self):
         while not self._doc.eof():
             data = self._read_to_next_section()
@@ -229,7 +221,6 @@ class NumpyDocString(collections.Mapping):
             else:
                 arg_name, arg_type = header, ''
 
-            arg_name = self._escape_args_and_kwargs(arg_name)
             desc = r.read_to_next_unindented_line()
             desc = dedent_lines(desc)
             desc = strip_blank_lines(desc)

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -199,6 +199,14 @@ class NumpyDocString(collections.Mapping):
 
         return section
 
+    def _escape_args_and_kwargs(self, name):
+        if name[:2] == '**':
+            return r'\*\*' + name[2:]
+        elif name[:1] == '*':
+            return r'\*' + name[1:]
+        else:
+            return name
+
     def _read_sections(self):
         while not self._doc.eof():
             data = self._read_to_next_section()
@@ -221,6 +229,7 @@ class NumpyDocString(collections.Mapping):
             else:
                 arg_name, arg_type = header, ''
 
+            arg_name = self._escape_args_and_kwargs(arg_name)
             desc = r.read_to_next_unindented_line()
             desc = dedent_lines(desc)
             desc = strip_blank_lines(desc)

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -131,6 +131,7 @@ class SphinxDocString(NumpyDocString):
         relies on Sphinx's plugin mechanism.
         """
         param = self._escape_args_and_kwargs(param.strip())
+        # param = param.strip()
         # XXX: If changing the following, please check the rendering when param
         # ends with '_', e.g. 'word_'
         # See https://github.com/numpy/numpydoc/pull/144

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -88,6 +88,14 @@ class SphinxDocString(NumpyDocString):
                 out += ['']
         return out
 
+    def _escape_args_and_kwargs(self, name):
+        if name[:2] == '**':
+            return r'\*\*' + name[2:]
+        elif name[:1] == '*':
+            return r'\*' + name[1:]
+        else:
+            return name
+
     def _process_param(self, param, desc, fake_autosummary):
         """Determine how to display a parameter
 
@@ -122,7 +130,7 @@ class SphinxDocString(NumpyDocString):
         complicated to incorporate autosummary's signature mangling, as it
         relies on Sphinx's plugin mechanism.
         """
-        param = param.strip()
+        param = self._escape_args_and_kwargs(param.strip())
         # XXX: If changing the following, please check the rendering when param
         # ends with '_', e.g. 'word_'
         # See https://github.com/numpy/numpydoc/pull/144

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1226,6 +1226,32 @@ def test_nonstandard_property():
     assert "test attribute" in str(doc)
 
 
+def test_args_and_kwargs():
+    cfg = dict()
+    doc = SphinxDocString("""
+    Parameters
+    ----------
+    param1 : int
+        First parameter
+    *args : tuple
+        Arguments
+    **kwargs : dict
+        Keyword arguments
+    """, config=cfg)
+    line_by_line_compare(str(doc), """
+:Parameters:
+
+    **param1** : int
+        First parameter
+
+    **\*args** : tuple
+        Arguments
+
+    **\*\*kwargs** : dict
+        Keyword arguments
+    """)
+
+
 if __name__ == "__main__":
     import nose
     nose.run()


### PR DESCRIPTION
Prevents sphinx from complaining

`WARNING: Inline strong start-string without end-string.`

Credit: Solution taken directly from sphinx.ext.napoleon