### PR TITLE
Use isdatadescriptor instead of isgetsetdescriptor

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -613,7 +613,7 @@ class ClassDoc(NumpyDocString):
         return [name for name, func in inspect.getmembers(self._cls)
                 if (not name.startswith('_') and
                     (func is None or isinstance(func, property) or
-                     inspect.isgetsetdescriptor(func))
+                     inspect.isdatadescriptor(func))
                     and self._is_show_member(name))]
 
     def _is_show_member(self, name):

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -242,7 +242,7 @@ class SphinxDocString(NumpyDocString):
                 param_obj = getattr(self._obj, param, None)
                 if not (callable(param_obj)
                         or isinstance(param_obj, property)
-                        or inspect.isgetsetdescriptor(param_obj)):
+                        or inspect.isdatadescriptor(param_obj)):
                     param_obj = None
 
                 if param_obj and pydoc.getdoc(param_obj):

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -15,7 +15,7 @@ from numpydoc.docscrape import (
     ParseError
 )
 from numpydoc.docscrape_sphinx import (SphinxDocString, SphinxClassDoc,
-                                       SphinxFunctionDoc)
+                                       SphinxFunctionDoc, get_doc_object)
 from nose.tools import (assert_equal, assert_raises, assert_list_equal,
                         assert_true)
 
@@ -1197,6 +1197,33 @@ def test_templated_sections():
             Bbb.
 
     """)
+
+
+def test_nonstandard_property():
+    # test discovery of a property that does not satisfy isinstace(.., property)
+
+    class SpecialProperty(object):
+
+        def __init__(self, axis=0, doc=""):
+            self.axis = axis
+            self.__doc__ = doc
+
+        def __get__(self, obj, type):
+            if obj is None:
+                # Only instances have actual _data, not classes
+                return self
+            else:
+                return obj._data.axes[self.axis]
+
+        def __set__(self, obj, value):
+            obj._set_axis(self.axis, value)
+
+    class Dummy:
+
+        attr = SpecialProperty(doc="test attribute")
+
+    doc = get_doc_object(Dummy)
+    assert "test attribute" in str(doc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a small change I did to our vendored version in pandas. Opening directly an PR instead of an issue as it is easier to show with the code. The reason for this is is because we have some properties in pandas defined on a DataFrame et al that are properties defined in cython. For those `isinstance(param_obj, property)` does not work (as expected), and `inspect.isgetsetdescriptor(param_obj))` also not, but apparently ` inspect.isdatadescriptor(param_obj))` does recognize them.

So although this is a useful change for pandas, I am not really sure about the possible implications. I don't really know the difference between "datadescriptor" and "getsetdescriptor", but from the docs it seems datadescriptor is a bit more general and also contains getsetdescriptor: https://docs.python.org/3.6/library/inspect.html#inspect.isdatadescriptor

(the safer option would actually be to *add* the check, instead of replacing) 