### PR TITLE
Towards fixing the Py2 bug in #163

### DIFF
--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -7,6 +7,7 @@ import textwrap
 import pydoc
 import collections
 import os
+import locale
 
 from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
@@ -146,6 +147,9 @@ class SphinxDocString(NumpyDocString):
                 or inspect.isgetsetdescriptor(param_obj)):
             param_obj = None
         obj_doc = pydoc.getdoc(param_obj)
+        if isinstance(obj_doc, bytes):
+            # reverse the encoding performed in getdoc
+            obj_doc = obj_doc.decode(locale.getpreferredencoding())
 
         if not (param_obj and obj_doc):
             return display_param, desc

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -829,6 +829,27 @@ def test_unicode():
     assert isinstance(doc['Summary'][0], str)
     assert doc['Summary'][0] == 'öäöäöäöäöåååå'
 
+    class UnicodeProperty(object):
+        """Class with Attribute having its own non-ascii docstring
+
+        Attributes
+        ----------
+        testattr : None
+            Description here is overwritten
+        testattr2 : None
+            Description here is overwritten
+        """
+        @property
+        def testattr(self):
+            """öäöäöäöäöåååå"""
+
+        @property
+        def testattr2(self):
+            u"""öäöäöäöäöåååå"""
+
+    doc = SphinxClassDoc(UnicodeProperty)
+    assert isinstance(str(doc), str)
+
 
 def test_plot_examples():
     cfg = dict(use_plots=True)


### PR DESCRIPTION
The error in #163 seems to come from a combination of changes between 0.7 and 0.8:
* our reimplementation of autosummary logic in listing attributes seems to mix unicode objects (from the currently processed dosctring) with native `str` due to `pydoc.getdoc` explicitly encoding its result (https://github.com/python/cpython/blob/2.7/Lib/pydoc.py#L85).
* the Jinja templating of docstrings might be forcing it to be unicode...?

I'm not sure yet how to fix this completely. SphinxDocString currently provides `__str__` and not `__unicode__`. But the `__str__` implementation can currently return a `unicode` in py2, resulting in automatic casting / encoding.