### PR TITLE
DOC: remove links to numpy repo file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,7 @@ numpydoc -- Numpy's Sphinx extensions
 =====================================
 
 This package provides the ``numpydoc`` Sphinx extension for handling
-docstrings formatted according to the `NumPy documentation format
-<https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`__.
+docstrings formatted according to the NumPy documentation format.
 The extension also adds the code description directives
 ``np:function``, ``np-c:function``, etc.
 

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -13,7 +13,7 @@ It will:
 - Extract the signature from the docstring, if it can't be determined
   otherwise.
 
-.. [1] https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+.. [1] https://github.com/numpy/numpydoc
 
 """
 from __future__ import division, absolute_import, print_function


### PR DESCRIPTION
this file is moving so remove the links to it. At some stage this repo should be the canonical source for documentation standardization, numpy should defer to here not the other way around