### PR TITLE
DOC: Add missing backslash to omega for inline math example.

### DIFF
--- a/doc/example.py
+++ b/doc/example.py
@@ -93,7 +93,7 @@ def foo(var1, var2, long_var_name='hi'):
 
     .. math:: X(e^{j\omega } ) = x(n)e^{ - j\omega n}
 
-    And even use a greek symbol like :math:`omega` inline.
+    And even use a Greek symbol like :math:`\omega` inline.
 
     References
     ----------


### PR DESCRIPTION
In doc/example.py capitalize "greek" and add a missing backslash to omega so that it shows up as a symbol rather then the word.