### PR TITLE
ENH: Added support for multiple functions+description in a See Also block

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -258,10 +258,7 @@ class NumpyDocString(Mapping):
                            r"`(?P<name>(?:~\w+\.)?[a-zA-Z0-9_.-]+)`|"
                            r" (?P<name2>[a-zA-Z0-9_.-]+))\s*", re.X)
 
-    if sys.version_info[0] >= 3:
-        zerowidthspace = '\u200B'
-    else:
-        zerowidthspace = '\xE2\x80\x8B'
+    empty_description = '..'
 
     def _parse_see_also(self, content):
         """
@@ -497,7 +494,7 @@ class NumpyDocString(Mapping):
                 last_had_desc = True
             else:
                 last_had_desc = False
-                out += self._str_indent([self.zerowidthspace])
+                out += self._str_indent([self.empty_description])
 
         if last_had_desc:
             out += ['']

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -243,9 +243,11 @@ class NumpyDocString(Mapping):
     # <FUNCNAME> ( COMMA SPACE+ <FUNCNAME>)* SPACE*
     # <FUNCNAME> ( COMMA SPACE+ <FUNCNAME>)* SPACE* COLON SPACE+ <DESC> SPACE*
 
-    # <FUNCNAME> is:
-    # A legal function name, optionally enclosed in backticks.
-    # It may have an optional COLON <ROLE> COLON in front where
+    # <FUNCNAME> is one of
+    #   <PLAIN_FUNCNAME>
+    #   COLON <ROLE> COLON BACKTICK <PLAIN_FUNCNAME> BACKTICK
+    # where
+    #   <PLAIN_FUNCNAME> is a legal function name, and
     #   <ROLE> is any nonempty sequence of word characters.
     # Examples: func_f1  :meth:`func_h1` :obj:`~baz.obj_r` :class:`class_j`
     # <DESC> is a string describing the function.
@@ -287,7 +289,7 @@ class NumpyDocString(Mapping):
             if not m:
                 raise ParseError("%s is not a item name" % text)
             role = m.group('role')
-            name = (m.group('name') if role else m.group('name2'))
+            name = m.group('name') if role else m.group('name2')
             return name, role, m.end()
 
         rest = []
@@ -470,7 +472,7 @@ class NumpyDocString(Mapping):
         out += ['']
         last_had_desc = True
         for funcs, desc in self['See Also']:
-            assert isinstance(funcs, (list, tuple))
+            assert isinstance(funcs, list)
             links = []
             for func, role in funcs:
                 if role:

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -492,15 +492,10 @@ class NumpyDocString(Mapping):
                 last_had_desc = True
             else:
                 last_had_desc = False
-                out += ['']
+                out += self._str_indent(['\u200B'])
         if last_had_desc:
             out += ['']
         out += ['']
-        # if 1:
-        #     print()
-        #     for l in out:
-        #         print(repr(l))
-        #     # print(out)
         return out
 
     def _str_index(self):

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -258,6 +258,11 @@ class NumpyDocString(Mapping):
                            r"`(?P<name>(?:~\w+\.)?[a-zA-Z0-9_.-]+)`|"
                            r" (?P<name2>[a-zA-Z0-9_.-]+))\s*", re.X)
 
+    if sys.version_info[0] >= 3:
+        zerowidthspace = '\u200B'
+    else:
+        zerowidthspace = '\xE2\x80\x8B'
+
     def _parse_see_also(self, content):
         """
         func_name : Descriptive text
@@ -492,7 +497,8 @@ class NumpyDocString(Mapping):
                 last_had_desc = True
             else:
                 last_had_desc = False
-                out += self._str_indent(['\u200B'])
+                out += self._str_indent([self.zerowidthspace])
+
         if last_had_desc:
             out += ['']
         out += ['']

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -243,16 +243,16 @@ class NumpyDocString(Mapping):
     _funcnamenext = _funcname.replace('role', 'rolenext').replace('name', 'namenext')
     _description = r"(?P<description>\s*:(\s+(?P<desc>\S+.*))?)?\s*$"
     _func_rgx = re.compile(r"^\s*" + _funcname + r"\s*", re.X)
-    # _funcs_rgx = re.compile(r"^\s*" + _funcname + r"(?P<morefuncs>([,\s]\s*" + _funcnamenext + r")*)" + r"\s*", re.X)
-    _line_rgx = re.compile(r"^\s*"
-                           + r"(?P<allfuncs>"            #  group for all function names
-                           + _funcname
-                           + r"(?P<morefuncs>([,]\s+"
-                           + _funcnamenext + r")*)"
-                           + r")"                        #  end of "allfuncs"
-                           + r"(\s*,)?"                  #  Some function lists have a trailing comma
-                           + _description,
-                           re.X)
+    _line_rgx = re.compile(
+        r"^\s*"
+        + r"(?P<allfuncs>"          # group for all function names
+        + _funcname
+        + r"(?P<morefuncs>([,]\s+"
+        + _funcnamenext + r")*)"
+        + r")"                      # end of "allfuncs"
+        + r"(\s*,)?"                # Some function lists have a trailing comma
+        + _description,
+        re.X)
 
     _name_rgx = re.compile(r"^\s*(:(?P<role>\w+):"
                            r"`(?P<name>(?:~\w+\.)?[a-zA-Z0-9_.-]+)`|"

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -331,14 +331,18 @@ def _strip_blank_lines(s):
 
 
 def line_by_line_compare(a, b):
-    empty_description = '..'
-    rgx = re.compile(r"^\s+" + re.escape(empty_description) + "$")
+    empty_description = NumpyDocString.empty_description  # '..'
+    empty_description_rgx = re.compile(
+        r"^\s+" + re.escape(empty_description) + "$")
 
     a = textwrap.dedent(a)
     b = textwrap.dedent(b)
-    a = [rgx.sub('', l.rstrip()) for l in _strip_blank_lines(a).split('\n')]
-    b = [rgx.sub('', l.rstrip()) for l in _strip_blank_lines(b).split('\n')]
+    a = [l.rstrip() for l in _strip_blank_lines(a).split('\n')]
+    b = [l.rstrip() for l in _strip_blank_lines(b).split('\n')]
+    a = [empty_description_rgx.sub('', l) for l in a]
+    b = [empty_description_rgx.sub('', l) for l in b]
     assert all(x == y for x, y in zip(a, b))
+
 
 def test_str():
     # doc_txt has the order of Notes and See Also sections flipped.
@@ -726,11 +730,11 @@ def test_see_also():
                         'func_g', 'func_h', 'func_j', 'func_k', 'baz.obj_q',
                         'func_f1', 'func_g1', 'func_h1', 'func_j1',
                         '~baz.obj_r'):
-                assert (not desc), str([func, desc])
+                assert not desc, str([func, desc])
             elif func in ('func_f2', 'func_g2', 'func_h2', 'func_j2'):
-                    assert (desc), str([func, desc])
+                assert desc, str([func, desc])
             else:
-                assert(desc), str([func, desc])
+                assert desc, str([func, desc])
 
             if func == 'func_h':
                 assert role == 'meth'

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -331,7 +331,7 @@ def _strip_blank_lines(s):
 
 
 def line_by_line_compare(a, b):
-    a = textwrap.dedent(a)
+    a = textwrap.dedent(a).replace(u'\u200B', '')
     b = textwrap.dedent(b)
     a = [l.rstrip() for l in _strip_blank_lines(a).split('\n')]
     b = [l.rstrip() for l in _strip_blank_lines(b).split('\n')]
@@ -717,9 +717,8 @@ def test_see_also():
         foobar
     """)
 
-    assert len(doc6['See Also']) == 10, str([len(doc6['See Also'])])
+    assert len(doc6['See Also']) == 10
     for funcs, desc in doc6['See Also']:
-        print(funcs, desc)
         for func, role in funcs:
             if func in ('func_a', 'func_b', 'func_c', 'func_f',
                         'func_g', 'func_h', 'func_j', 'func_k', 'baz.obj_q',
@@ -748,12 +747,8 @@ def test_see_also():
                 assert desc == ['some other func over', 'multiple lines']
             elif func == 'class_j':
                 assert desc == ['fubar', 'foobar']
-            elif func == 'func_j2':
+            elif func in ['func_f2', 'func_g2', 'func_h2', 'func_j2']:
                 assert desc == ['description of multiple'], str([desc, ['description of multiple']])
-
-        # s = str(doc6)
-        # print(repr(s))
-        # assert 1 == 0
 
 
 def test_see_also_parse_error():

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -331,17 +331,14 @@ def _strip_blank_lines(s):
 
 
 def line_by_line_compare(a, b):
-    if sys.version_info.major >= 3:
-        zerowidthspace = '\u200B'
-    else:
-        zerowidthspace = '\xE2\x80\x8B'
+    empty_description = '..'
+    rgx = re.compile(r"^\s+" + re.escape(empty_description) + "$")
 
-    a = textwrap.dedent(a).replace(zerowidthspace, '')
+    a = textwrap.dedent(a)
     b = textwrap.dedent(b)
-    a = [l.rstrip() for l in _strip_blank_lines(a).split('\n')]
-    b = [l.rstrip() for l in _strip_blank_lines(b).split('\n')]
+    a = [rgx.sub('', l.rstrip()) for l in _strip_blank_lines(a).split('\n')]
+    b = [rgx.sub('', l.rstrip()) for l in _strip_blank_lines(b).split('\n')]
     assert all(x == y for x, y in zip(a, b))
-
 
 def test_str():
     # doc_txt has the order of Notes and See Also sections flipped.

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -331,7 +331,12 @@ def _strip_blank_lines(s):
 
 
 def line_by_line_compare(a, b):
-    a = textwrap.dedent(a).replace(u'\u200B', '')
+    if sys.version_info.major >= 3:
+        zerowidthspace = '\u200B'
+    else:
+        zerowidthspace = '\xE2\x80\x8B'
+
+    a = textwrap.dedent(a).replace(zerowidthspace, '')
     b = textwrap.dedent(b)
     a = [l.rstrip() for l in _strip_blank_lines(a).split('\n')]
     b = [l.rstrip() for l in _strip_blank_lines(b).split('\n')]

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -709,36 +709,51 @@ def test_see_also():
              multiple lines
     func_f, func_g, :meth:`func_h`, func_j,
     func_k
+    func_f1, func_g1, :meth:`func_h1`, func_j1
+    func_f2, func_g2, :meth:`func_h2`, func_j2 : description of multiple
     :obj:`baz.obj_q`
     :obj:`~baz.obj_r`
     :class:`class_j`: fubar
         foobar
     """)
 
-    assert len(doc6['See Also']) == 13
-    for func, desc, role in doc6['See Also']:
-        if func in ('func_a', 'func_b', 'func_c', 'func_f',
-                    'func_g', 'func_h', 'func_j', 'func_k', 'baz.obj_q',
-                    '~baz.obj_r'):
-            assert(not desc)
-        else:
-            assert(desc)
+    assert len(doc6['See Also']) == 10, str([len(doc6['See Also'])])
+    for funcs, desc in doc6['See Also']:
+        print(funcs, desc)
+        for func, role in funcs:
+            if func in ('func_a', 'func_b', 'func_c', 'func_f',
+                        'func_g', 'func_h', 'func_j', 'func_k', 'baz.obj_q',
+                        'func_f1', 'func_g1', 'func_h1', 'func_j1',
+                        '~baz.obj_r'):
+                assert (not desc), str([func, desc])
+            elif func in ('func_f2', 'func_g2', 'func_h2', 'func_j2'):
+                    assert (desc), str([func, desc])
+            else:
+                assert(desc), str([func, desc])
 
-        if func == 'func_h':
-            assert role == 'meth'
-        elif func == 'baz.obj_q' or func == '~baz.obj_r':
-            assert role == 'obj'
-        elif func == 'class_j':
-            assert role == 'class'
-        else:
-            assert role is None
+            if func == 'func_h':
+                assert role == 'meth'
+            elif func == 'baz.obj_q' or func == '~baz.obj_r':
+                assert role == 'obj'
+            elif func == 'class_j':
+                assert role == 'class'
+            elif func in ['func_h1', 'func_h2']:
+                assert role == 'meth'
+            else:
+                assert role is None, str([func, role])
 
-        if func == 'func_d':
-            assert desc == ['some equivalent func']
-        elif func == 'foo.func_e':
-            assert desc == ['some other func over', 'multiple lines']
-        elif func == 'class_j':
-            assert desc == ['fubar', 'foobar']
+            if func == 'func_d':
+                assert desc == ['some equivalent func']
+            elif func == 'foo.func_e':
+                assert desc == ['some other func over', 'multiple lines']
+            elif func == 'class_j':
+                assert desc == ['fubar', 'foobar']
+            elif func == 'func_j2':
+                assert desc == ['description of multiple'], str([desc, ['description of multiple']])
+
+        # s = str(doc6)
+        # print(repr(s))
+        # assert 1 == 0
 
 
 def test_see_also_parse_error():

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -331,17 +331,11 @@ def _strip_blank_lines(s):
 
 
 def line_by_line_compare(a, b):
-    empty_description = NumpyDocString.empty_description  # '..'
-    empty_description_rgx = re.compile(
-        r"^\s+" + re.escape(empty_description) + "$")
-
     a = textwrap.dedent(a)
     b = textwrap.dedent(b)
     a = [l.rstrip() for l in _strip_blank_lines(a).split('\n')]
     b = [l.rstrip() for l in _strip_blank_lines(b).split('\n')]
-    a = [empty_description_rgx.sub('', l) for l in a]
-    b = [empty_description_rgx.sub('', l) for l in b]
-    assert all(x == y for x, y in zip(a, b))
+    assert all(x == y for x, y in zip(a, b)), str([[x, y] for x, y in zip(a, b) if x != y])
 
 
 def test_str():
@@ -409,7 +403,7 @@ See Also
 --------
 
 `some`_, `other`_, `funcs`_
-
+    ..
 `otherfunc`_
     relationship
 
@@ -559,7 +553,7 @@ of the one-dimensional normal distribution to higher dimensions.
 .. seealso::
 
     :obj:`some`, :obj:`other`, :obj:`funcs`
-
+        ..
     :obj:`otherfunc`
         relationship
 


### PR DESCRIPTION
Addresses gh-170.  Extended capabilities of See Also blocks. No longer silently drops descriptions from lines with multiple functions.
Supports 
1. `<FUNCNAME>`
2. `<FUNCNAME> <SPACE>* COLON SPACE+ <DESCRIPTION> SPACE*`
3. `<FUNCNAME> ( COMMA SPACE+ <FUNCNAME>)* SPACE*`
4. `<FUNCNAME> ( COMMA SPACE+ <FUNCNAME>)* SPACE* COLON SPACE+ <DESCRIPTION> SPACE*`

Empty `<DESCRIPTION>` elements are replaced with a Unicode ZERO-WIDTH SPACE `"    \u200B"` in the output of `docscrape.py`. That is sufficient to convince the subsequent processing that the definition is present for the purposes of continuing the definition list.  Further processing replaces the string `"    \u200B"` with `""`, so that teh zero-width space doesn't appear in the generated HTML.

Closes #28