### PR TITLE
FIX parsing of type-only return params

### DIFF
--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -70,19 +70,19 @@ class SphinxDocString(NumpyDocString):
         return self['Extended Summary'] + ['']
 
     def _str_returns(self, name='Returns'):
-        typed_fmt = '**%s** : %s'
-        untyped_fmt = '**%s**'
+        named_fmt = '**%s** : %s'
+        unnamed_fmt = '%s'
 
         out = []
         if self[name]:
             out += self._str_field_list(name)
             out += ['']
             for param in self[name]:
-                if param.type:
-                    out += self._str_indent([typed_fmt % (param.name.strip(),
+                if param.name:
+                    out += self._str_indent([named_fmt % (param.name.strip(),
                                                           param.type)])
                 else:
-                    out += self._str_indent([untyped_fmt % param.name.strip()])
+                    out += self._str_indent([unnamed_fmt % param.type.strip()])
                 if not param.desc:
                     out += self._str_indent(['..'], 8)
                 else:
@@ -209,12 +209,13 @@ class SphinxDocString(NumpyDocString):
                 display_param, desc = self._process_param(param.name,
                                                           param.desc,
                                                           fake_autosummary)
-
+                parts = []
+                if display_param:
+                    parts.append(display_param)
                 if param.type:
-                    out += self._str_indent(['%s : %s' % (display_param,
-                                                          param.type)])
-                else:
-                    out += self._str_indent([display_param])
+                    parts.append(param.type)
+                out += self._str_indent([' : '.join(parts)])
+
                 if desc and self.use_blockquotes:
                     out += ['']
                 elif not desc:
@@ -376,8 +377,8 @@ class SphinxDocString(NumpyDocString):
             'yields': self._str_returns('Yields'),
             'receives': self._str_returns('Receives'),
             'other_parameters': self._str_param_list('Other Parameters'),
-            'raises': self._str_param_list('Raises'),
-            'warns': self._str_param_list('Warns'),
+            'raises': self._str_returns('Raises'),
+            'warns': self._str_returns('Warns'),
             'warnings': self._str_warnings(),
             'see_also': self._str_see_also(func_role),
             'notes': self._str_section('Notes'),

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -211,14 +211,14 @@ def test_returns():
     assert desc[-1].endswith('distribution.')
 
     arg, arg_type, desc = doc['Returns'][1]
-    assert arg == 'list of str'
-    assert arg_type == ''
+    assert arg == ''
+    assert arg_type == 'list of str'
     assert desc[0].startswith('This is not a real')
     assert desc[-1].endswith('anonymous return values.')
 
     arg, arg_type, desc = doc['Returns'][2]
-    assert arg == 'no_description'
-    assert arg_type == ''
+    assert arg == ''
+    assert arg_type == 'no_description'
     assert not ''.join(desc).strip()
 
 
@@ -227,7 +227,7 @@ def test_yields():
     assert len(section) == 3
     truth = [('a', 'int', 'apples.'),
              ('b', 'int', 'bananas.'),
-             ('int', '', 'unknowns.')]
+             ('', 'int', 'unknowns.')]
     for (arg, arg_type, desc), (arg_, arg_type_, end) in zip(section, truth):
         assert arg == arg_
         assert arg_type == arg_type_
@@ -594,11 +594,11 @@ of the one-dimensional normal distribution to higher dimensions.
         In other words, each entry ``out[i,j,...,:]`` is an N-dimensional
         value drawn from the distribution.
 
-    **list of str**
+    list of str
         This is not a real return value.  It exists to test
         anonymous return values.
 
-    **no_description**
+    no_description
         ..
 
 :Other Parameters:
@@ -608,12 +608,12 @@ of the one-dimensional normal distribution to higher dimensions.
 
 :Raises:
 
-    **RuntimeError**
+    RuntimeError
         Some error
 
 :Warns:
 
-    **RuntimeWarning**
+    RuntimeWarning
         Some warning
 
 .. warning::
@@ -687,7 +687,7 @@ def test_sphinx_yields_str():
     **b** : int
         The number of bananas.
 
-    **int**
+    int
         The number of unknowns.
 """)
 
@@ -754,16 +754,18 @@ doc5 = NumpyDocString(
 
 def test_raises():
     assert len(doc5['Raises']) == 1
-    name, _, desc = doc5['Raises'][0]
-    assert name == 'LinAlgException'
-    assert desc == ['If array is singular.']
+    param = doc5['Raises'][0]
+    assert param.name == ''
+    assert param.type == 'LinAlgException'
+    assert param.desc == ['If array is singular.']
 
 
 def test_warns():
     assert len(doc5['Warns']) == 1
-    name, _, desc = doc5['Warns'][0]
-    assert name == 'SomeWarning'
-    assert desc == ['If needed']
+    param = doc5['Warns'][0]
+    assert param.name == ''
+    assert param.type == 'SomeWarning'
+    assert param.desc == ['If needed']
 
 
 def test_see_also():
@@ -995,7 +997,7 @@ def test_use_blockquotes():
 
             GHI
 
-        **JKL**
+        JKL
 
             MNO
     ''')


### PR DESCRIPTION
Fixes #72.

The sections "Parameters" and "Returns" have different semantics for single-element parameter headers. For "Parameters", the header is the name, for "Returns" the header is the type. This was not reflected in the code as both sections used the same parser.

Note: This is just a quick write-up how the code should work. I've not yet let run the tests (they may need fixing as well as mentioned in #72). But for brevity I'll let CI decide on that.