### PR TITLE
FIX pedantic handling of whitespace in reference regex

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -50,7 +50,8 @@ def rename_references(app, what, name, obj, options, lines):
     references = set()
     for line in lines:
         line = line.strip()
-        m = re.match(sixu('^.. \\[(%s)\\]') % app.config.numpydoc_citation_re,
+        m = re.match(sixu(r'^\.\. +\[(%s)\]') %
+                     app.config.numpydoc_citation_re,
                      line, re.I)
         if m:
             references.add(m.group(1))


### PR DESCRIPTION
In https://github.com/scikit-learn/scikit-learn/pull/11241 I landed on an issue where numpy did not rename a reference that had two spaces between `..` and `[ref]`. When fixing this I noted that the `.`s should also be escaped in the regex.