### PR TITLE
Move setup of autosummary earlier in setup().

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -176,6 +176,8 @@ def setup(app, get_doc_object_=get_doc_object):
     global get_doc_object
     get_doc_object = get_doc_object_
 
+    app.setup_extension('sphinx.ext.autosummary')
+
     app.connect('autodoc-process-docstring', mangle_docstrings)
     app.connect('autodoc-process-signature', mangle_signature)
     app.connect('doctree-read', relabel_references)
@@ -190,8 +192,6 @@ def setup(app, get_doc_object_=get_doc_object):
     # Extra mangling domains
     app.add_domain(NumpyPythonDomain)
     app.add_domain(NumpyCDomain)
-
-    app.setup_extension('sphinx.ext.autosummary')
 
     metadata = {'version': __version__,
                 'parallel_read_safe': True}


### PR DESCRIPTION
`setup()` calls `app.setup_extension('sphinx.ext.autosummary')` so that
end users who add numpydoc to their extension list don't need to declare
a dependency on autosummary, but we may just as well move the call to
setup_extension even earlier, which also removes the need to declare a
dependency on autodoc (as autosummary will initialize it).

Otherwise, users need to be careful to have autodoc *before* numpydoc
in their extension list; without that they get an "Unknown event name:
autodoc-process-docstring" error.