### PR TITLE
FIX: Fix collections.abc imports

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -8,7 +8,11 @@ import textwrap
 import re
 import pydoc
 from warnings import warn
-import collections
+from collections import namedtuple
+try:
+    from collections.abc import Callable, Mapping
+except ImportError:
+    from collections import Callable, Mapping
 import copy
 import sys
 
@@ -106,10 +110,10 @@ class ParseError(Exception):
         return message
 
 
-Parameter = collections.namedtuple('Parameter', ['name', 'type', 'desc'])
+Parameter = namedtuple('Parameter', ['name', 'type', 'desc'])
 
 
-class NumpyDocString(collections.Mapping):
+class NumpyDocString(Mapping):
     """Parses a numpydoc string to an abstract representation
 
     Instances define a mapping from section title to structured data.
@@ -607,7 +611,7 @@ class ClassDoc(NumpyDocString):
         return [name for name, func in inspect.getmembers(self._cls)
                 if ((not name.startswith('_')
                      or name in self.extra_public_methods)
-                    and isinstance(func, collections.Callable)
+                    and isinstance(func, Callable)
                     and self._is_show_member(name))]
 
     @property

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -5,7 +5,10 @@ import re
 import inspect
 import textwrap
 import pydoc
-import collections
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 import os
 
 from jinja2 import FileSystemLoader
@@ -413,7 +416,7 @@ def get_doc_object(obj, what=None, doc=None, config={}, builder=None):
             what = 'class'
         elif inspect.ismodule(obj):
             what = 'module'
-        elif isinstance(obj, collections.Callable):
+        elif isinstance(obj, Callable):
             what = 'function'
         else:
             what = 'object'

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -22,7 +22,10 @@ import sys
 import re
 import pydoc
 import inspect
-import collections
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 import hashlib
 
 from docutils.nodes import citation, Text
@@ -156,7 +159,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
             'initializes x; see ' in pydoc.getdoc(obj.__init__))):
         return '', ''
 
-    if not (isinstance(obj, collections.Callable) or
+    if not (isinstance(obj, Callable) or
             hasattr(obj, '__argspec_is_invalid_')):
         return
 


### PR DESCRIPTION
Avoid Python3.7 warnings of the form:

> DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
