### PR TITLE
Clarify location of certain invalid docstrings.

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -32,7 +32,7 @@ from sphinx.addnodes import pending_xref, desc_content
 if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
 
-from .docscrape_sphinx import get_doc_object, SphinxDocString
+from .docscrape_sphinx import get_doc_object
 from . import __version__
 
 if sys.version_info[0] >= 3:
@@ -162,7 +162,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
     if not hasattr(obj, '__doc__'):
         return
-    doc = SphinxDocString(pydoc.getdoc(obj))
+    doc = get_doc_object(obj)
     sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
     if sig:
         sig = re.sub(sixu("^[^(]*"), sixu(""), sig)


### PR DESCRIPTION
Closes #115 Closes #123

If one adds the following invalid docstring at the end of
`doc/example.py`
```
def bar():
    """
    Parameters
    ----------
    a : int

    Parameters
    ----------
    b : float
    """
```
then as of numpydoc master the error message is
```
ValueError: The section Parameters appears twice in the docstring of None in None.
```

This patch fixes the error message to give
```
ValueError: The section Parameters appears twice in the docstring of <function bar at 0x7fa5c9d20e18> in /path/to/numpydoc/doc/example.py.
```

Initially noticed at https://github.com/matplotlib/matplotlib/pull/11859#issuecomment-457935237.