### PR TITLE
BUG: turn member descriptor attributes into links

### DIFF
--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -147,7 +147,8 @@ class SphinxDocString(NumpyDocString):
         param_obj = getattr(self._obj, param, None)
         if not (callable(param_obj)
                 or isinstance(param_obj, property)
-                or inspect.isgetsetdescriptor(param_obj)):
+                or inspect.isgetsetdescriptor(param_obj)
+                or inspect.ismemberdescriptor(param_obj)):
             param_obj = None
         obj_doc = pydoc.getdoc(param_obj)
 


### PR DESCRIPTION
This turns the member descriptors attributes into links, see for instance the [member descriptors](https://docs.python.org/2/library/inspect.html#inspect.ismemberdescriptor) of [numpy.broadcast](https://docs.scipy.org/doc/numpy-1.16.1/reference/generated/numpy.broadcast.html) `nd`, `ndim`, and `numiter` which were inlined, not linked.

I originally got to this since the documentation of those descriptors has an `Example` section. Inlining it rather than linking causes sphinx to complain that there is more than one `Example` section.

I am not sure how to write a test for this, as it requires a c-extension to define the member descriptors.

Perhaps this code could be refactored to check for a positive result, not a negative one