### PR TITLE
MAINT: Add CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ jobs:
               pip install --user -q --upgrade pip setuptools
               pip install --user -q --upgrade numpy matplotlib sphinx
               pip install --user -e .
+              git submodule init
+              git submodule update
         - save_cache:
             key: pip-cache
             paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+version: 2
+jobs:
+    build_docs:
+      docker:
+        - image: circleci/python:3.7-stretch
+      steps:
+        - checkout
+        - run:
+            name: Set BASH_ENV
+            command: |
+              echo "set -e" >> $BASH_ENV;
+              echo "export PATH=~/.local/bin:$PATH" >> $BASH_ENV;
+        - restore_cache:
+            keys:
+              - pip-cache
+        - run:
+            name: Get dependencies and install
+            command: |
+              pip install --user -q --upgrade pip setuptools
+              pip install --user -q --upgrade numpy matplotlib sphinx
+              pip install --user -e .
+        - save_cache:
+            key: pip-cache
+            paths:
+              - ~/.cache/pip
+        - run:
+            name: make html
+            command: |
+              cd doc
+              make html
+        - store_artifacts:
+            path: doc/_build/html/
+            destination: html
+
+workflows:
+  version: 2
+
+  default:
+    jobs:
+      - build_docs

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@
 *.egg-info
 *.swp
 *.swo
+.pytest_cache
+doc/_build
 build
 dist


### PR DESCRIPTION
I wanted to browse and link to built docs in #197 but didn't see a way to do it. This should make it easy to view hopefully.

I don't have permissions for the NumPy org to tick the box here to enable it:

https://circleci.com/add-projects/gh/numpy

@rgommers or some other suitably permissioned person, could you enable it? Then I can iterate here until it works.

Eventually this could easily probably amended to upload to `readthedocs`, not sure if it's already automated or not.