### PR TITLE
Updating minimum sphinx version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author_email="pav@iki.fi",
     url="https://numpydoc.readthedocs.io",
     license="BSD",
-    install_requires=["sphinx >= 1.2.3", 'Jinja2>=2.3'],
+    install_requires=["sphinx >= 1.6.5", 'Jinja2>=2.3'],
     package_data={'numpydoc': ['tests/test_*.py', 'templates/*.rst']},
     test_suite = 'nose.collector',
     cmdclass={"sdist": sdist},


### PR DESCRIPTION
Fixes #210 

I'm seeing the `getLogger` error message in our CI but then in `setup.py` the fact that it should work with 1.2.3 has sent me into some dead-ends.

```
    logger = logging.getLogger(__name__)
AttributeError: module 'sphinx.util.logging' has no attribute 'getLogger'
```