### PR TITLE
BUG: Defer to autodoc for signatures 

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -93,9 +93,6 @@ numpydoc_xref_ignore : set
         numpydoc_xref_ignore = {'type', 'optional', 'default'}
 
     The default is an empty set.
-numpydoc_use_autodoc_signature : bool
-    Should numpydoc defer to Sphinx's autodoc to format the signature?
-    ``False`` by default.
 numpydoc_edit_link : bool
   .. deprecated:: edit your HTML template instead
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -94,9 +94,8 @@ numpydoc_xref_ignore : set
 
     The default is an empty set.
 numpydoc_use_autodoc_signature : bool
-    Should numpydoc attempt to create signatures for functions or defer to
-    sphinx autodoc?
-    ``False`` by default. 
+    Should numpydoc defer to Sphinx's autodoc to format the signature?
+    ``False`` by default.
 numpydoc_edit_link : bool
   .. deprecated:: edit your HTML template instead
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -93,6 +93,10 @@ numpydoc_xref_ignore : set
         numpydoc_xref_ignore = {'type', 'optional', 'default'}
 
     The default is an empty set.
+numpydoc_use_autodoc_signature : bool
+    Should numpydoc attempt to create signatures for functions or defer to
+    sphinx autodoc?
+    ``False`` by default. 
 numpydoc_edit_link : bool
   .. deprecated:: edit your HTML template instead
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -71,3 +71,21 @@ Additional notes
 
    -  https://github.com/numpy/numpydoc/issues/215#issuecomment-568261611
    -  https://github.com/readthedocs/sphinx_rtd_theme/pull/838
+
+1.1.0
+-----
+
+Fixed bugs
+~~~~~~~~~~
+
+-  BUG: Defer to autodoc for signatures `#221 <https://github.com/numpy/numpydoc/pull/221>`__ (`thequackdaddy <https://github.com/thequackdaddy>`__)
+
+Closed issues
+~~~~~~~~~~~~~
+
+-  self included in list of params for method `#220 <https://github.com/numpy/numpydoc/issues/220>`__
+
+Additional notes
+~~~~~~~~~~~~~~~~
+
+-  Due to merging of `#221 <https://github.com/numpy/numpydoc/pull/221>`__, self and cls no longer will appear in method signatures.

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -566,25 +566,6 @@ class FunctionDoc(NumpyDocString):
             doc = inspect.getdoc(func) or ''
         NumpyDocString.__init__(self, doc, config)
 
-        use_autodoc_signature = config.get('use_autodoc_signature', False)
-
-        if (not self['Signature'] and func is not None
-                and not use_autodoc_signature):
-            func, func_name = self.get_func()
-            try:
-                try:
-                    signature = str(inspect.signature(func))
-                except (AttributeError, ValueError):
-                    # try to read signature, backward compat for older Python
-                    if sys.version_info[0] >= 3:
-                        argspec = inspect.getfullargspec(func)
-                    else:
-                        argspec = inspect.getargspec(func)
-                    signature = inspect.formatargspec(*argspec)
-                signature = '%s%s' % (func_name, signature)
-            except TypeError:
-                signature = '%s()' % func_name
-            self['Signature'] = signature
 
     def get_func(self):
         func_name = getattr(self._f, '__name__', self.__class__.__name__)

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -566,7 +566,10 @@ class FunctionDoc(NumpyDocString):
             doc = inspect.getdoc(func) or ''
         NumpyDocString.__init__(self, doc, config)
 
-        if not self['Signature'] and func is not None:
+        use_autodoc_signature = config.get('use_autodoc_signature', False)
+
+        if (not self['Signature'] and func is not None
+                and not use_autodoc_signature):
             func, func_name = self.get_func()
             try:
                 try:

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -566,7 +566,6 @@ class FunctionDoc(NumpyDocString):
             doc = inspect.getdoc(func) or ''
         NumpyDocString.__init__(self, doc, config)
 
-
     def get_func(self):
         func_name = getattr(self._f, '__name__', self.__class__.__name__)
         if inspect.isclass(self._f):

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -206,7 +206,8 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
     sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
     if sig:
         sig = re.sub("^[^(]*", "", sig)
-        sig = re.sub("$", "", sig)
+        sig = re.sub(r"\$self,\s", "", sig)
+        sig = re.sub(r"\/,\s", "", sig)
         return sig, ''
 
 

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -202,11 +202,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
     if not hasattr(obj, '__doc__'):
         return
-
-    cfg = {'use_autodoc_signature': app.config.numpydoc_use_autodoc_signature,
-           'show_class_members': False}
-
-    doc = get_doc_object(obj, config=cfg)
+    doc = get_doc_object(obj, config={'show_class_members': False})
     sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
     if sig:
         sig = re.sub("^[^(]*", "", sig)
@@ -230,7 +226,6 @@ def setup(app, get_doc_object_=get_doc_object):
     app.add_config_value('numpydoc_edit_link', None, False)
     app.add_config_value('numpydoc_use_plots', None, False)
     app.add_config_value('numpydoc_use_blockquotes', None, False)
-    app.add_config_value('numpydoc_use_autodoc_signature', False, False)
     app.add_config_value('numpydoc_show_class_members', True, True)
     app.add_config_value('numpydoc_show_inherited_class_members', True, True)
     app.add_config_value('numpydoc_class_members_toctree', True, True)

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -203,8 +203,8 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
     if not hasattr(obj, '__doc__'):
         return
     doc = get_doc_object(obj, config={'show_class_members': False})
-    sig = (doc['Signature'] or
-           _clean_text_signature(getattr(obj, '__text_signature__', None)))
+    sig = (doc['Signature']
+           or _clean_text_signature(getattr(obj, '__text_signature__', None)))
     if sig:
         sig = re.sub("^[^(]*", "", sig)
         return sig, ''
@@ -213,12 +213,11 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 def _clean_text_signature(sig):
     if sig is None:
         return None
-    start_pattern = re.compile(r"^[^(]*\(*")
+    start_pattern = re.compile(r"^[^(]*\(")
     start, end = start_pattern.search(sig).span()
     start_sig = sig[start:end]
-    sig = sig[end:]
-    sig = re.sub(r"\)", "", sig)
-    params = sig.replace(' ', '').split(',')
+    sig = sig[end:-1]
+    params = sig.split(', ')
     for param in ('$self', '$module', '$type', '/'):
         if param in params:
             params.remove(param)

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -203,12 +203,28 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
     if not hasattr(obj, '__doc__'):
         return
     doc = get_doc_object(obj, config={'show_class_members': False})
-    sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
+    sig = (doc['Signature'] or
+           _clean_text_signature(getattr(obj, '__text_signature__', None)))
     if sig:
         sig = re.sub("^[^(]*", "", sig)
-        sig = re.sub(r"\$self,\s", "", sig)
-        sig = re.sub(r"\/,\s", "", sig)
         return sig, ''
+
+
+def _clean_text_signature(sig):
+    if sig is None:
+        return None
+    sig = re.sub(r"^[^(]*\(", "", sig)
+    sig = re.sub(r"\)", "", sig)
+    params = sig.replace(' ', '').split(',')
+    if '$self' in params:
+        params.remove('$self')
+    if '$module' in params:
+        params.remove('$module')
+    if '$type' in params:
+        params.remove('$type')
+    if '/' in params:
+        params.remove('/')
+    return '(' + ', '.join(params) + ')'
 
 
 def setup(app, get_doc_object_=get_doc_object):

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -202,7 +202,11 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
     if not hasattr(obj, '__doc__'):
         return
-    doc = get_doc_object(obj, config={'show_class_members': False})
+
+    cfg = {'use_autodoc_signature': app.config.numpydoc_use_autodoc_signature,
+           'show_class_members': False}
+
+    doc = get_doc_object(obj, config=cfg)
     sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
     if sig:
         sig = re.sub("^[^(]*", "", sig)
@@ -226,6 +230,7 @@ def setup(app, get_doc_object_=get_doc_object):
     app.add_config_value('numpydoc_edit_link', None, False)
     app.add_config_value('numpydoc_use_plots', None, False)
     app.add_config_value('numpydoc_use_blockquotes', None, False)
+    app.add_config_value('numpydoc_use_autodoc_signature', False, False)
     app.add_config_value('numpydoc_show_class_members', True, True)
     app.add_config_value('numpydoc_show_inherited_class_members', True, True)
     app.add_config_value('numpydoc_class_members_toctree', True, True)

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -217,11 +217,9 @@ def _clean_text_signature(sig):
     start, end = start_pattern.search(sig).span()
     start_sig = sig[start:end]
     sig = sig[end:-1]
-    params = sig.split(', ')
-    for param in ('$self', '$module', '$type', '/'):
-        if param in params:
-            params.remove(param)
-    return start_sig + ', '.join(params) + ')'
+    sig = re.sub(r'^\$(self|module|type)(,\s|$)','' , sig, count=1)
+    sig = re.sub(r'(^|(?<=,\s))/,\s\*', '*', sig, count=1)
+    return start_sig + sig + ')'
 
 
 def setup(app, get_doc_object_=get_doc_object):

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -213,18 +213,16 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 def _clean_text_signature(sig):
     if sig is None:
         return None
-    sig = re.sub(r"^[^(]*\(", "", sig)
+    start_pattern = re.compile(r"^[^(]*\(*")
+    start, end = start_pattern.search(sig).span()
+    start_sig = sig[start:end]
+    sig = sig[end:]
     sig = re.sub(r"\)", "", sig)
     params = sig.replace(' ', '').split(',')
-    if '$self' in params:
-        params.remove('$self')
-    if '$module' in params:
-        params.remove('$module')
-    if '$type' in params:
-        params.remove('$type')
-    if '/' in params:
-        params.remove('/')
-    return '(' + ', '.join(params) + ')'
+    for param in ('$self', '$module', '$type', '/'):
+        if param in params:
+            params.remove(param)
+    return start_sig + ', '.join(params) + ')'
 
 
 def setup(app, get_doc_object_=get_doc_object):

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -206,6 +206,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
     sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
     if sig:
         sig = re.sub("^[^(]*", "", sig)
+        sig = re.sub("$", "", sig)
         return sig, ''
 
 

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1484,6 +1484,35 @@ def test_xref():
     line_by_line_compare(str(doc), xref_doc_txt_expected)
 
 
+def test_signature_inspect():
+
+    def func1(a):
+        pass
+
+    def func2(a, b):
+        pass
+
+    class klass:
+        def __init__(self, a, b):
+            pass
+
+        def meth1(self, a, b):
+            pass
+
+        def meth2(a, b):
+            pass
+
+        @classmethod
+        def meth3(a, b):
+            pass
+
+    assert get_doc_object(func1)['Signature'] == 'func1(a)'
+    assert get_doc_object(func2)['Signature'] == 'func2(a, b)'
+    assert get_doc_object(klass.meth1)['Signature'] == 'meth1(a, b)'
+    assert get_doc_object(klass.meth2)['Signature'] == 'meth2(b)'
+    assert get_doc_object(klass.meth3)['Signature'] == 'meth3(a, b)'
+
+
 if __name__ == "__main__":
     import pytest
     pytest.main()

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -691,17 +691,6 @@ doc3 = NumpyDocString("""
     """)
 
 
-def test_escape_stars():
-    signature = str(doc3).split('\n')[0]
-    assert signature == r'my_signature(\*params, \*\*kwds)'
-
-    def my_func(a, b, **kwargs):
-        pass
-
-    fdoc = FunctionDoc(func=my_func)
-    assert fdoc['Signature'] == 'my_func(a, b, **kwargs)'
-
-
 doc4 = NumpyDocString(
     """a.conj()
 
@@ -1482,47 +1471,6 @@ def test_xref():
     )
 
     line_by_line_compare(str(doc), xref_doc_txt_expected)
-
-
-def test_signature_inspect():
-
-    def func1(a):
-        pass
-
-    def func2(a, b):
-        pass
-
-    class klass:
-        def __init__(self, a, b):
-            pass
-
-        def meth1(self, a, b):
-            pass
-
-        def meth2(a, b):
-            pass
-
-        @classmethod
-        def meth3(a, b):
-            pass
-
-    assert get_doc_object(func1)['Signature'] == 'func1(a)'
-    assert get_doc_object(func2)['Signature'] == 'func2(a, b)'
-    assert get_doc_object(klass.meth1)['Signature'] == 'meth1(self, a, b)'
-    assert get_doc_object(klass.meth2)['Signature'] == 'meth2(a, b)'
-    if sys.version_info[0] >= 3:
-        assert get_doc_object(klass.meth3)['Signature'] == 'meth3(b)'
-    else:
-        assert get_doc_object(klass.meth3)['Signature'] == 'meth3(a, b)'
-
-    assert get_doc_object(func1, 'use_autodoc_signature')['Signature'] == ''
-    assert get_doc_object(func2, 'use_autodoc_signature')['Signature'] == ''
-    assert get_doc_object(klass.meth1,
-                          'use_autodoc_signature')['Signature'] == ''
-    assert get_doc_object(klass.meth2,
-                          'use_autodoc_signature')['Signature'] == ''
-    assert get_doc_object(klass.meth3,
-                          'use_autodoc_signature')['Signature'] == ''
 
 
 if __name__ == "__main__":

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -699,7 +699,7 @@ def test_escape_stars():
         pass
 
     fdoc = FunctionDoc(func=my_func)
-    assert fdoc['Signature'] == 'my_func(a, b, **kwargs)'
+    assert fdoc['Signature'] == ''
 
 
 doc4 = NumpyDocString(

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -691,6 +691,17 @@ doc3 = NumpyDocString("""
     """)
 
 
+def test_escape_stars():
+    signature = str(doc3).split('\n')[0]
+    assert signature == r'my_signature(\*params, \*\*kwds)'
+
+    def my_func(a, b, **kwargs):
+        pass
+
+    fdoc = FunctionDoc(func=my_func)
+    assert fdoc['Signature'] == 'my_func(a, b, **kwargs)'
+
+
 doc4 = NumpyDocString(
     """a.conj()
 

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1510,7 +1510,10 @@ def test_signature_inspect():
     assert get_doc_object(func2)['Signature'] == 'func2(a, b)'
     assert get_doc_object(klass.meth1)['Signature'] == 'meth1(self, a, b)'
     assert get_doc_object(klass.meth2)['Signature'] == 'meth2(a, b)'
-    assert get_doc_object(klass.meth3)['Signature'] == 'meth3(b)'
+    if sys.version_info[0] >= 3:
+        assert get_doc_object(klass.meth3)['Signature'] == 'meth3(b)'
+    else:
+        assert get_doc_object(klass.meth3)['Signature'] == 'meth3(a, b)'
 
     assert get_doc_object(func1, 'use_autodoc_signature')['Signature'] == ''
     assert get_doc_object(func2, 'use_autodoc_signature')['Signature'] == ''

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1508,9 +1508,18 @@ def test_signature_inspect():
 
     assert get_doc_object(func1)['Signature'] == 'func1(a)'
     assert get_doc_object(func2)['Signature'] == 'func2(a, b)'
-    assert get_doc_object(klass.meth1)['Signature'] == 'meth1(a, b)'
-    assert get_doc_object(klass.meth2)['Signature'] == 'meth2(b)'
-    assert get_doc_object(klass.meth3)['Signature'] == 'meth3(a, b)'
+    assert get_doc_object(klass.meth1)['Signature'] == 'meth1(self, a, b)'
+    assert get_doc_object(klass.meth2)['Signature'] == 'meth2(a, b)'
+    assert get_doc_object(klass.meth3)['Signature'] == 'meth3(b)'
+
+    assert get_doc_object(func1, 'use_autodoc_signature')['Signature'] == ''
+    assert get_doc_object(func2, 'use_autodoc_signature')['Signature'] == ''
+    assert get_doc_object(klass.meth1,
+                          'use_autodoc_signature')['Signature'] == ''
+    assert get_doc_object(klass.meth2,
+                          'use_autodoc_signature')['Signature'] == ''
+    assert get_doc_object(klass.meth3,
+                          'use_autodoc_signature')['Signature'] == ''
 
 
 if __name__ == "__main__":

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -58,7 +58,7 @@ def test_MyClass(sphinx_app):
     # if we see a \* in the output we know it's incorrect:
     assert r'\*' not in html
     # "self" should not be in the parameter list for the class:
-    assert 'self,' in html   # XXX should be "not in", bug!
+    assert 'self,' not in html
     # check xref was embedded properly (dict should link using xref):
     assert 'stdtypes.html#dict' in html
 

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -53,6 +53,7 @@ def test_MyClass(sphinx_app):
         html = fid.read()
     # ensure that no autodoc weirdness ($) occurs
     assert '$self' not in html
+    assert '/,' not in html
     assert '__init__' in html  # inherited
     # escaped * chars should no longer be preceded by \'s,
     # if we see a \* in the output we know it's incorrect:

--- a/numpydoc/tests/test_numpydoc.py
+++ b/numpydoc/tests/test_numpydoc.py
@@ -76,6 +76,18 @@ def test_clean_text_signature():
             == 'func(*args, **kwargs)')
     assert _clean_text_signature('($module)') == '()'
     assert _clean_text_signature('func($type)') == 'func()'
+    assert (_clean_text_signature('func($self, foo="hello world")')
+            == 'func(foo="hello world")')
+    assert (_clean_text_signature("func($self, foo='hello world')")
+            == "func(foo='hello world')")
+    assert (_clean_text_signature('func(foo="hello world")')
+            == 'func(foo="hello world")')
+    assert (_clean_text_signature('func(foo="$self")')
+            == 'func(foo="$self")')
+    assert (_clean_text_signature('func($self, foo="$self")')
+            == 'func(foo="$self")')
+    assert _clean_text_signature('func(self, other)') == 'func(self, other)'
+    assert _clean_text_signature('func(self, $self)') == 'func(self)'
 
 
 if __name__ == "__main__":

--- a/numpydoc/tests/test_numpydoc.py
+++ b/numpydoc/tests/test_numpydoc.py
@@ -1,6 +1,6 @@
 # -*- encoding:utf-8 -*-
 from copy import deepcopy
-from numpydoc.numpydoc import mangle_docstrings
+from numpydoc.numpydoc import mangle_docstrings, _clean_text_signature
 from numpydoc.xref import DEFAULT_LINKS
 from sphinx.ext.autodoc import ALL
 
@@ -62,6 +62,20 @@ A top section before
         MockApp(), 'class', 'str', str, {'exclude-members': ['upper']}, lines)
     assert 'rpartition' in [x.strip() for x in lines]
     assert 'upper' not in [x.strip() for x in lines]
+
+
+def test_clean_text_signature():
+    assert _clean_text_signature(None) is None
+    assert _clean_text_signature('func($self)') == '()'
+    assert (_clean_text_signature('func($self, *args, **kwargs)') ==
+            '(*args, **kwargs)')
+    assert _clean_text_signature('($self)') == '()'
+    assert _clean_text_signature('()') == '()'
+    assert _clean_text_signature('func()') == '()'
+    assert (_clean_text_signature('func($self, /, *args, **kwargs)') ==
+            '(*args, **kwargs)')
+    assert _clean_text_signature('($module)') == '()'
+    assert _clean_text_signature('func($type)') == '()'
 
 
 if __name__ == "__main__":

--- a/numpydoc/tests/test_numpydoc.py
+++ b/numpydoc/tests/test_numpydoc.py
@@ -74,6 +74,8 @@ def test_clean_text_signature():
     assert _clean_text_signature('func()') == 'func()'
     assert (_clean_text_signature('func($self, /, *args, **kwargs)')
             == 'func(*args, **kwargs)')
+    assert (_clean_text_signature('func($self, other, /, *args, **kwargs)')
+            == 'func(other, *args, **kwargs)')
     assert _clean_text_signature('($module)') == '()'
     assert _clean_text_signature('func($type)') == 'func()'
     assert (_clean_text_signature('func($self, foo="hello world")')
@@ -87,7 +89,7 @@ def test_clean_text_signature():
     assert (_clean_text_signature('func($self, foo="$self")')
             == 'func(foo="$self")')
     assert _clean_text_signature('func(self, other)') == 'func(self, other)'
-    assert _clean_text_signature('func(self, $self)') == 'func(self)'
+    assert _clean_text_signature('func($self, *args)') == 'func(*args)'
 
 
 if __name__ == "__main__":

--- a/numpydoc/tests/test_numpydoc.py
+++ b/numpydoc/tests/test_numpydoc.py
@@ -36,7 +36,7 @@ app.builder.app = app
 
 
 def test_mangle_docstrings():
-    s ='''
+    s = '''
 A top section before
 
 .. autoclass:: str
@@ -66,16 +66,16 @@ A top section before
 
 def test_clean_text_signature():
     assert _clean_text_signature(None) is None
-    assert _clean_text_signature('func($self)') == '()'
-    assert (_clean_text_signature('func($self, *args, **kwargs)') ==
-            '(*args, **kwargs)')
+    assert _clean_text_signature('func($self)') == 'func()'
+    assert (_clean_text_signature('func($self, *args, **kwargs)')
+            == 'func(*args, **kwargs)')
     assert _clean_text_signature('($self)') == '()'
     assert _clean_text_signature('()') == '()'
-    assert _clean_text_signature('func()') == '()'
-    assert (_clean_text_signature('func($self, /, *args, **kwargs)') ==
-            '(*args, **kwargs)')
+    assert _clean_text_signature('func()') == 'func()'
+    assert (_clean_text_signature('func($self, /, *args, **kwargs)')
+            == 'func(*args, **kwargs)')
     assert _clean_text_signature('($module)') == '()'
-    assert _clean_text_signature('func($type)') == '()'
+    assert _clean_text_signature('func($type)') == 'func()'
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
xref #220

I think this should pass. It fails because method signatures include `self`. 

I'll be happy to help make this pass. 