### PR TITLE
MAINT: fix trivial source comment typos

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -54,7 +54,7 @@ numpydoc_xref_param_type : bool
   ``False`` by default.
 
   .. note:: Depending on the link types, the CSS styles might be different.
-            consider overridding e.g. ``span.classifier a span.xref`` and
+            consider overriding e.g. ``span.classifier a span.xref`` and
             ``span.classifier a code.docutils.literal.notranslate``
             CSS classes to achieve a uniform appearance.
 

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -139,7 +139,7 @@ def clean_backrefs(app, doc, docname):
         for id_ in ref['ids']:
             known_ref_ids.add(id_)
     for citation_node in doc.traverse(citation, descend=True):
-        # remove backrefs to non-existant refs
+        # remove backrefs to non-existent refs
         citation_node['backrefs'] = [id_ for id_ in citation_node['backrefs']
                                      if id_ in known_ref_ids]
 

--- a/numpydoc/xref.py
+++ b/numpydoc/xref.py
@@ -141,7 +141,7 @@ def make_xref(param_type, xref_aliases, xref_ignore):
                 else:
                     res = make_xref(
                         tok, xref_aliases, xref_ignore)
-                    # Openning brackets immediated after a role is
+                    # Opening brackets immediately after a role is
                     # bad markup. Detect that and add backslash.
                     # :role:`type`( to :role:`type`\(
                     if res and res[-1] == '`' and i < n-1:


### PR DESCRIPTION
Found via `codespell`