### PR TITLE
BUG: Fix full rebuilds

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -18,6 +18,7 @@ It will:
 """
 from __future__ import division, absolute_import, print_function
 
+from copy import deepcopy
 import sys
 import re
 import pydoc
@@ -160,7 +161,7 @@ def mangle_docstrings(app, what, name, obj, options, lines):
            'attributes_as_param_list':
            app.config.numpydoc_attributes_as_param_list,
            'xref_param_type': app.config.numpydoc_xref_param_type,
-           'xref_aliases': app.config.numpydoc_xref_aliases,
+           'xref_aliases': app.config.numpydoc_xref_aliases_complete,
            'xref_ignore': app.config.numpydoc_xref_ignore,
            }
 
@@ -258,9 +259,15 @@ def setup(app, get_doc_object_=get_doc_object):
 
 def update_config(app):
     """Update the configuration with default values."""
+    # Do not simply overwrite the `app.config.numpydoc_xref_aliases`
+    # otherwise the next sphinx-build will compare the incoming values (without
+    # our additions) to the old values (with our additions) and trigger
+    # a full rebuild!
+    numpydoc_xref_aliases_complete = deepcopy(app.config.numpydoc_xref_aliases)
     for key, value in DEFAULT_LINKS.items():
-        if key not in app.config.numpydoc_xref_aliases:
-            app.config.numpydoc_xref_aliases[key] = value
+        if key not in numpydoc_xref_aliases_complete:
+            numpydoc_xref_aliases_complete[key] = value
+    app.config.numpydoc_xref_aliases_complete = numpydoc_xref_aliases_complete
 
 
 # ------------------------------------------------------------------------------

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -2,6 +2,7 @@
 from __future__ import division, absolute_import, print_function
 
 from collections import namedtuple
+from copy import deepcopy
 import re
 import sys
 import textwrap
@@ -10,6 +11,7 @@ import warnings
 import jinja2
 
 from numpydoc.numpydoc import update_config
+from numpydoc.xref import DEFAULT_LINKS
 from numpydoc.docscrape import (
     NumpyDocString,
     FunctionDoc,
@@ -1485,8 +1487,16 @@ def test_xref():
     xref_aliases = {
         'sequence': ':obj:`python:sequence`',
     }
-    config = namedtuple('numpydoc_xref_aliases',
-                        'numpydoc_xref_aliases')(xref_aliases)
+
+    class Config():
+        def __init__(self, a, b):
+            self.numpydoc_xref_aliases = a
+            self.numpydoc_xref_aliases_complete = b
+
+    xref_aliases_complete = deepcopy(DEFAULT_LINKS)
+    for key in xref_aliases:
+        xref_aliases_complete[key] = xref_aliases[key]
+    config = Config(xref_aliases, xref_aliases_complete)
     app = namedtuple('config', 'config')(config)
     update_config(app)
 
@@ -1496,7 +1506,7 @@ def test_xref():
         xref_doc_txt,
         config=dict(
             xref_param_type=True,
-            xref_aliases=xref_aliases,
+            xref_aliases=xref_aliases_complete,
             xref_ignore=xref_ignore
         )
     )

--- a/numpydoc/tests/test_numpydoc.py
+++ b/numpydoc/tests/test_numpydoc.py
@@ -1,8 +1,11 @@
 # -*- encoding:utf-8 -*-
 from __future__ import division, absolute_import, print_function
 
+from copy import deepcopy
 from numpydoc.numpydoc import mangle_docstrings
+from numpydoc.xref import DEFAULT_LINKS
 from sphinx.ext.autodoc import ALL
+
 
 class MockConfig():
     numpydoc_use_plots = False
@@ -12,14 +15,17 @@ class MockConfig():
     numpydoc_class_members_toctree = True
     numpydoc_xref_param_type = False
     numpydoc_xref_aliases = {}
+    numpydoc_xref_aliases_complete = deepcopy(DEFAULT_LINKS)
     numpydoc_xref_ignore = set()
     templates_path = []
     numpydoc_edit_link = False
     numpydoc_citation_re = '[a-z0-9_.-]+'
     numpydoc_attributes_as_param_list = True
 
+
 class MockBuilder():
     config = MockConfig()
+
 
 class MockApp():
     config = MockConfig()
@@ -29,6 +35,7 @@ class MockApp():
 
 app = MockApp()
 app.builder.app = app
+
 
 def test_mangle_docstrings():
     s ='''
@@ -55,6 +62,7 @@ A top section before
                             {'exclude-members': ['upper']}, lines)
     assert 'rpartition' in [x.strip() for x in lines]
     assert 'upper' not in [x.strip() for x in lines]
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
I realized that my Sphinx was always doing a full rebuild. It's because with `xref` we modify the config to add some values after the builder is initted. But then this env gets pickled and saved to disk, so on the next sphinx build run it compares the user's config (which does not have these values) to the pickled config (which has the added values) which triggers a full rebuild every time.

This fixes it by instead just checking our set after the user's set when doing the `xref` step. It's a tiny bit less efficient but should not be too much of a slowdown.