### PR TITLE
DOC: Add description for blank lines after the docstring.

### DIFF
--- a/doc/example.py
+++ b/doc/example.py
@@ -119,5 +119,8 @@ def foo(var1, var2, long_var_name='hi'):
     b
 
     """
-
+    # After closing class docstring, there should be one blank line to
+    # separate following codes (according to PEP257).
+    # But for function, method and module, there should be no blank lines
+    # after closing the docstring.
     pass


### PR DESCRIPTION
This is mainly a discussion, I notice that there is a blank line between the closing quotes and the `pass`:
```python
...
"""

pass
```

But from the PEP 257, it seems that there are no blank lines after the function docstring (no specific statement, but the examples in it don't contain the blank line). And the blank line separation only requires for class docstring:

> Insert a blank line after all docstrings (one-line or multi-line) that document a class -- generally speaking, the class's methods are separated from each other by a single blank line, and the docstring needs to be offset from the first method by a blank line. ([source](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings))

So I am wondering: should we specifically suggest no the blank line after the functions/methods docstring OR it just doesn't matter and people can choose whatever they like?