### PR TITLE
ENH: Test full output and coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+branch = True
+source = numpydoc
+include = */numpydoc/*
+omit =
+    */setup.py

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ doc/_build
 build
 dist
 doc/_build
+numpydoc/tests/tinybuild/_build
+numpydoc/tests/tinybuild/generated

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist
 doc/_build
 numpydoc/tests/tinybuild/_build
 numpydoc/tests/tinybuild/generated
+MANIFEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 before_install:
   - sudo apt-get install texlive texlive-latex-extra latexmk
   - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
-  - pip install pytest pytest-cov numpy matplotlib sphinx${SPHINX_SPEC}
+  - pip install pytest pytest-cov pytest-sugar numpy matplotlib sphinx${SPHINX_SPEC} codecov
 script:
   - |
     python setup.py sdist
@@ -26,3 +26,7 @@ script:
     cd ../doc
     make SPHINXOPTS=$SPHINXOPTS html
     make SPHINXOPTS=$SPHINXOPTS latexpdf
+after_script:
+  - |
+    cd ../dist
+    codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@
 language: python
 dist: xenial
 sudo: false
+addons:
+  apt:
+    packages:
+    - dvipng
 matrix:
   include:
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ addons:
   apt:
     packages:
     - dvipng
+    - texlive
+    - texlive-latex-extra
+    - latexmk
 matrix:
   include:
     - python: 3.7
@@ -16,16 +19,15 @@ matrix:
 cache:
   directories:
     - $HOME/.cache/pip
-before_install:
-  - sudo apt-get install texlive texlive-latex-extra latexmk
+install:
   - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
-  - pip install pytest pytest-cov pytest-sugar numpy matplotlib sphinx${SPHINX_SPEC} codecov
+  - pip install pytest pytest-cov numpy matplotlib sphinx${SPHINX_SPEC} codecov
 script:
   - |
     python setup.py sdist
     cd dist
     pip install numpydoc* -v
-  - pytest --pyargs numpydoc
+  - pytest -v --pyargs numpydoc
   - |
     cd ../doc
     make SPHINXOPTS=$SPHINXOPTS html

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,6 @@
 language: python
 dist: xenial
 sudo: false
-addons:
-  apt:
-    packages:
-    - dvipng
-    - texlive
-    - texlive-latex-extra
-    - latexmk
 matrix:
   include:
     - python: 3.7
@@ -19,7 +12,8 @@ matrix:
 cache:
   directories:
     - $HOME/.cache/pip
-install:
+before_install:
+  - sudo apt-get install texlive texlive-latex-extra latexmk dvipng
   - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
   - pip install pytest pytest-cov numpy matplotlib sphinx${SPHINX_SPEC} codecov
 script:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.01
+    patch: false
+    changes: false
+comment:
+  layout: "header, diff, sunburst, uncovered"
+  behavior: default

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -1,3 +1,4 @@
+from io import StringIO
 import os.path as op
 import shutil
 
@@ -26,7 +27,7 @@ def sphinx_app(tmpdir_factory):
     # https://github.com/sphinx-doc/sphinx/issues/5038
     with docutils_namespace():
         app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
-                     buildername='html')
+                     buildername='html', status=StringIO(u''))
         # need to build within the context manager
         # for automodule and backrefs to work
         app.build(False, [])

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -46,6 +46,8 @@ def test_class(sphinx_app):
     # escaped * chars should no longer be preceded by \'s
     assert r'\*' in html  # XXX should be "not in", bug!
     assert 'self,' in html   # XXX should be "not in", bug!
+    # check xref
+    assert 'stdtypes.html#dict' in html
 
 
 def test_function(sphinx_app):
@@ -57,3 +59,5 @@ def test_function(sphinx_app):
         html = fid.read()
     assert r'\*args' not in html
     assert '*args' in html
+    # check xref
+    assert 'glossary.html#term-iterable' in html

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -1,4 +1,3 @@
-from io import StringIO
 import os.path as op
 import shutil
 
@@ -27,7 +26,7 @@ def sphinx_app(tmpdir_factory):
     # https://github.com/sphinx-doc/sphinx/issues/5038
     with docutils_namespace():
         app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
-                     buildername='html', status=StringIO(u''))
+                     buildername='html')
         # need to build within the context manager
         # for automodule and backrefs to work
         app.build(False, [])
@@ -40,7 +39,7 @@ def test_class(sphinx_app):
     class_rst = op.join(src_dir, 'generated', 'nd_test_mod.MyClass.rst')
     with open(class_rst, 'r') as fid:
         rst = fid.read()
-    assert r'nd\_test\_mod.MyClass' in rst  # properly escaped
+    assert r'nd\_test\_mod' in rst  # properly escaped
     class_html = op.join(out_dir, 'generated', 'nd_test_mod.MyClass.html')
     with open(class_html, 'r') as fid:
         html = fid.read()

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -1,0 +1,60 @@
+from io import StringIO
+import os.path as op
+import shutil
+
+import pytest
+from sphinx.application import Sphinx
+from sphinx.util.docutils import docutils_namespace
+
+
+# Test framework adapted from sphinx-gallery
+@pytest.fixture(scope='module')
+def sphinx_app(tmpdir_factory):
+    temp_dir = (tmpdir_factory.getbasetemp() / 'root').strpath
+    src_dir = op.join(op.dirname(__file__), 'tinybuild')
+
+    def ignore(src, names):
+        return ('_build', 'generated')
+
+    shutil.copytree(src_dir, temp_dir, ignore=ignore)
+    # For testing iteration, you can get similar behavior just doing `make`
+    # inside the tinybuild directory
+    src_dir = temp_dir
+    conf_dir = temp_dir
+    out_dir = op.join(temp_dir, '_build', 'html')
+    toctrees_dir = op.join(temp_dir, '_build', 'toctrees')
+    # Avoid warnings about re-registration, see:
+    # https://github.com/sphinx-doc/sphinx/issues/5038
+    with docutils_namespace():
+        app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
+                     buildername='html', status=StringIO())
+        # need to build within the context manager
+        # for automodule and backrefs to work
+        app.build(False, [])
+    return app
+
+
+def test_class(sphinx_app):
+    """Test that class documentation is reasonable."""
+    src_dir, out_dir = sphinx_app.srcdir, sphinx_app.outdir
+    class_rst = op.join(src_dir, 'generated', 'nd_test_mod.MyClass.rst')
+    with open(class_rst, 'r') as fid:
+        rst = fid.read()
+    assert r'nd\_test\_mod.MyClass' in rst  # properly escaped
+    class_html = op.join(out_dir, 'generated', 'nd_test_mod.MyClass.html')
+    with open(class_html, 'r') as fid:
+        html = fid.read()
+    # escaped * chars should no longer be preceded by \'s
+    assert r'\*' in html  # XXX should be "not in", bug!
+    assert 'self,' in html   # XXX should be "not in", bug!
+
+
+def test_function(sphinx_app):
+    """Test that a timings page is created."""
+    out_dir = sphinx_app.outdir
+    function_html = op.join(out_dir, 'generated',
+                            'nd_test_mod.my_function.html')
+    with open(function_html, 'r') as fid:
+        html = fid.read()
+    assert r'\*args' not in html
+    assert '*args' in html

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -6,7 +6,7 @@ from sphinx.application import Sphinx
 from sphinx.util.docutils import docutils_namespace
 
 
-# Test framework adapted from sphinx-gallery
+# Test framework adapted from sphinx-gallery (BSD 3-clause)
 @pytest.fixture(scope='module')
 def sphinx_app(tmpdir_factory):
     temp_dir = (tmpdir_factory.getbasetemp() / 'root').strpath
@@ -33,31 +33,35 @@ def sphinx_app(tmpdir_factory):
     return app
 
 
-def test_class(sphinx_app):
+def test_MyClass(sphinx_app):
     """Test that class documentation is reasonable."""
     src_dir, out_dir = sphinx_app.srcdir, sphinx_app.outdir
-    class_rst = op.join(src_dir, 'generated', 'nd_test_mod.MyClass.rst')
+    class_rst = op.join(src_dir, 'generated',
+                        'numpydoc_test_module.MyClass.rst')
     with open(class_rst, 'r') as fid:
         rst = fid.read()
-    assert r'nd\_test\_mod' in rst  # properly escaped
-    class_html = op.join(out_dir, 'generated', 'nd_test_mod.MyClass.html')
+    assert r'numpydoc\_test\_module' in rst  # properly escaped
+    class_html = op.join(out_dir, 'generated',
+                         'numpydoc_test_module.MyClass.html')
     with open(class_html, 'r') as fid:
         html = fid.read()
-    # escaped * chars should no longer be preceded by \'s
+    # escaped * chars should no longer be preceded by \'s,
+    # if we see a \* in the output we know it's incorrect:
     assert r'\*' in html  # XXX should be "not in", bug!
+    # "self" should not be in the parameter list for the class:
     assert 'self,' in html   # XXX should be "not in", bug!
-    # check xref
+    # check xref was embedded properly (dict should link using xref):
     assert 'stdtypes.html#dict' in html
 
 
-def test_function(sphinx_app):
+def test_my_function(sphinx_app):
     """Test that a timings page is created."""
     out_dir = sphinx_app.outdir
     function_html = op.join(out_dir, 'generated',
-                            'nd_test_mod.my_function.html')
+                            'numpydoc_test_module.my_function.html')
     with open(function_html, 'r') as fid:
         html = fid.read()
     assert r'\*args' not in html
     assert '*args' in html
-    # check xref
+    # check xref (iterable should link using xref):
     assert 'glossary.html#term-iterable' in html

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -1,4 +1,3 @@
-from io import StringIO
 import os.path as op
 import shutil
 
@@ -27,7 +26,7 @@ def sphinx_app(tmpdir_factory):
     # https://github.com/sphinx-doc/sphinx/issues/5038
     with docutils_namespace():
         app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
-                     buildername='html', status=StringIO())
+                     buildername='html')
         # need to build within the context manager
         # for automodule and backrefs to work
         app.build(False, [])

--- a/numpydoc/tests/tinybuild/Makefile
+++ b/numpydoc/tests/tinybuild/Makefile
@@ -1,0 +1,11 @@
+all: clean html show
+
+clean:
+	rm -rf _build/*
+	rm -rf generated/
+
+html:
+	sphinx-build -b html -d _build/doctrees . _build/html
+
+show:
+	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/_build/html/index.html')"

--- a/numpydoc/tests/tinybuild/conf.py
+++ b/numpydoc/tests/tinybuild/conf.py
@@ -1,0 +1,22 @@
+import os
+import sys
+path = os.path.dirname(__file__)
+if path not in sys.path:
+    sys.path.insert(0, path)
+import nd_test_mod  # noqa
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'numpydoc',
+]
+project = 'nd_test_mod'
+autosummary_generate = True
+source_suffix = '.rst'
+master_doc = 'index'
+exclude_patterns = ['_build']
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}
+nitpicky = True
+highlight_language = 'python3'
+numpydoc_xref_param_type = True

--- a/numpydoc/tests/tinybuild/conf.py
+++ b/numpydoc/tests/tinybuild/conf.py
@@ -3,13 +3,13 @@ import sys
 path = os.path.dirname(__file__)
 if path not in sys.path:
     sys.path.insert(0, path)
-import nd_test_mod  # noqa
+import numpydoc_test_module  # noqa
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'numpydoc',
 ]
-project = 'nd_test_mod'
+project = 'numpydoc_test_module'
 autosummary_generate = True
 source_suffix = '.rst'
 master_doc = 'index'

--- a/numpydoc/tests/tinybuild/index.rst
+++ b/numpydoc/tests/tinybuild/index.rst
@@ -1,4 +1,4 @@
-nd_test_mod
-===========
+numpydoc_test_module
+====================
 
-.. automodule:: nd_test_mod
+.. automodule:: numpydoc_test_module

--- a/numpydoc/tests/tinybuild/index.rst
+++ b/numpydoc/tests/tinybuild/index.rst
@@ -1,0 +1,4 @@
+nd_test_mod
+===========
+
+.. automodule:: nd_test_mod

--- a/numpydoc/tests/tinybuild/nd_test_mod.py
+++ b/numpydoc/tests/tinybuild/nd_test_mod.py
@@ -1,0 +1,51 @@
+"""Numpdoc test module.
+
+.. currentmodule:: nd_test_mod
+
+.. autosummary::
+   :toctree: generated/
+
+   MyClass
+   my_function
+"""
+
+__all__ = ['MyClass', 'my_function']
+
+
+class MyClass(object):
+    """A class.
+
+    Parameters
+    ----------
+    *args : iterable
+        Arguments.
+    **kwargs : dict
+        Keyword arguments.
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def my_function(*args, **kwargs):
+    """Return None.
+
+    See [1]_.
+
+    Parameters
+    ----------
+    *args : iterable
+        Arguments.
+    **kwargs : dict
+        Keyword arguments.
+
+    Returns
+    -------
+    out : None
+        The output.
+
+    References
+    ----------
+    .. [1] https://numpydoc.readthedocs.io
+    """
+    return None

--- a/numpydoc/tests/tinybuild/numpydoc_test_module.py
+++ b/numpydoc/tests/tinybuild/numpydoc_test_module.py
@@ -1,6 +1,6 @@
-"""Numpdoc test module.
+"""Numpydoc test module.
 
-.. currentmodule:: nd_test_mod
+.. currentmodule:: numpydoc_test_module
 
 .. autosummary::
    :toctree: generated/

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@ addopts =
     --showlocals --doctest-modules -ra --cov-report= --cov=numpydoc
     --junit-xml=junit-results.xml --ignore=doc/conf.py
 filterwarnings =
+    ignore:'U' mode is deprecated:DeprecationWarning
     ignore:Using or importing the ABCs.*:DeprecationWarning
-

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,12 @@ setup(
     url="https://numpydoc.readthedocs.io",
     license="BSD",
     install_requires=["sphinx >= 1.6.5", 'Jinja2>=2.3'],
-    package_data={'numpydoc': ['tests/test_*.py', 'templates/*.rst']},
-    test_suite = 'nose.collector',
+    package_data={'numpydoc': [
+        'tests/test_*.py',
+        'tests/tinybuild/Makefile',
+        'tests/tinybuild/index.rst',
+        'tests/tinybuild/*.py',
+        'templates/*.rst',
+        ]},
     cmdclass={"sdist": sdist},
 )


### PR DESCRIPTION
Over in Sphinx-gallery for about a year we've been testing full builds of sphinx using Pytest:

https://github.com/sphinx-gallery/sphinx-gallery/blob/master/sphinx_gallery/tests/test_full.py

It's convenient because:

1. You can add assertions about the HTML that you get in `pytest` form.
2. You can easily interactively test by doing `make clean; make html` from within the `numpydoc/tests/tinybuild` directory and looking at the rendered HTML.
3. You can easily add more test cases by adding new things to be documented in the `nd_test_mod` module in `tinybuild`.

I've shown how to use this framework in some basic cases here. I've also added some assertions that are bad (marked by `XXX`) that #221 should fix (@thequackdaddy after this PR is merged and you rebase, you can change a couple of `in`s below to `not in`s to assert that the `*args, **kwargs` situation has been fixed).

This PR also attempts to enable `codecov`.