### PR TITLE
MNT Drop Python 2.7 and 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ sudo: false
 matrix:
   include:
     - python: 3.7
+    - python: 3.6
+      env: SPHINX_SPEC="==2.1.0" SPHINXOPTS=""
+    - python: 3.5
       env: SPHINX_SPEC="==1.6.5" SPHINXOPTS=""
-    - python: 3.7
-    - python: 2.7
 cache:
   directories:
     - $HOME/.cache/pip

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,8 @@ docstrings formatted according to the NumPy documentation format.
 The extension also adds the code description directives
 ``np:function``, ``np-c:function``, etc.
 
+numpydoc requires Python 3.5+ and sphinx 1.6.5+.
+
 For usage information, please refer to the `documentation
 <https://numpydoc.readthedocs.io/>`_.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-The extension is available from:
+This extension requires Python 3.5+, sphinx 1.6.5+ and is available from:
 
 * `numpydoc on PyPI <http://pypi.python.org/pypi/numpydoc>`_
 * `numpydoc on GitHub <https://github.com/numpy/numpydoc/>`_

--- a/numpydoc/__init__.py
+++ b/numpydoc/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 __version__ = '1.0.0.dev0'
 
 

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -1,18 +1,13 @@
 """Extract reference documentation from the NumPy source tree.
 
 """
-from __future__ import division, absolute_import, print_function
-
 import inspect
 import textwrap
 import re
 import pydoc
 from warnings import warn
 from collections import namedtuple
-try:
-    from collections.abc import Callable, Mapping
-except ImportError:
-    from collections import Callable, Mapping
+from collections.abc import Callable, Mapping
 import copy
 import sys
 

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -1,14 +1,8 @@
-from __future__ import division, absolute_import, print_function
-
-import sys
 import re
 import inspect
 import textwrap
 import pydoc
-try:
-    from collections.abc import Callable
-except ImportError:
-    from collections import Callable
+from collections.abc import Callable
 import os
 
 from jinja2 import FileSystemLoader
@@ -18,11 +12,6 @@ from sphinx.jinja2glue import BuiltinTemplateLoader
 
 from .docscrape import NumpyDocString, FunctionDoc, ClassDoc
 from .xref import make_xref
-
-if sys.version_info[0] >= 3:
-    sixu = lambda s: s
-else:
-    sixu = lambda s: unicode(s, 'unicode_escape')
 
 
 IMPORT_MATPLOTLIB_RE = r'\b(import +matplotlib|from +matplotlib +import)\b'
@@ -290,12 +279,12 @@ class SphinxDocString(NumpyDocString):
 
             if others:
                 maxlen_0 = max(3, max([len(p.name) + 4 for p in others]))
-                hdr = sixu("=") * maxlen_0 + sixu("  ") + sixu("=") * 10
-                fmt = sixu('%%%ds  %%s  ') % (maxlen_0,)
+                hdr = "=" * maxlen_0 + "  " + "=" * 10
+                fmt = '%%%ds  %%s  ' % (maxlen_0,)
                 out += ['', '', hdr]
                 for param in others:
                     name = "**" + param.name.strip() + "**"
-                    desc = sixu(" ").join(x.strip()
+                    desc = " ".join(x.strip()
                                           for x in param.desc).strip()
                     if param.type:
                         desc = "(%s) %s" % (param.type, desc)

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -16,17 +16,11 @@ It will:
 .. [1] https://github.com/numpy/numpydoc
 
 """
-from __future__ import division, absolute_import, print_function
-
 from copy import deepcopy
-import sys
 import re
 import pydoc
 import inspect
-try:
-    from collections.abc import Callable
-except ImportError:
-    from collections import Callable
+from collections.abc import Callable
 import hashlib
 import itertools
 
@@ -35,20 +29,14 @@ import sphinx
 from sphinx.addnodes import pending_xref, desc_content
 from sphinx.util import logging
 
-if sphinx.__version__ < '1.0.1':
-    raise RuntimeError("Sphinx 1.0.1 or newer is required")
+if sphinx.__version__ < '1.6.5':
+    raise RuntimeError("Sphinx 1.6.5 or newer is required")
 
 from .docscrape_sphinx import get_doc_object
 from .xref import DEFAULT_LINKS
 from . import __version__
 
 logger = logging.getLogger(__name__)
-
-if sys.version_info[0] >= 3:
-    sixu = lambda s: s
-else:
-    sixu = lambda s: unicode(s, 'unicode_escape')
-
 
 HASH_LEN = 12
 
@@ -58,7 +46,7 @@ def rename_references(app, what, name, obj, options, lines):
     references = set()
     for line in lines:
         line = line.strip()
-        m = re.match(sixu(r'^\.\. +\[(%s)\]') %
+        m = re.match(r'^\.\. +\[(%s)\]' %
                      app.config.numpydoc_citation_re,
                      line, re.I)
         if m:
@@ -73,10 +61,10 @@ def rename_references(app, what, name, obj, options, lines):
         for r in references:
             new_r = prefix + '-' + r
             for i, line in enumerate(lines):
-                lines[i] = lines[i].replace(sixu('[%s]_') % r,
-                                            sixu('[%s]_') % new_r)
-                lines[i] = lines[i].replace(sixu('.. [%s]') % r,
-                                            sixu('.. [%s]') % new_r)
+                lines[i] = lines[i].replace('[%s]_' % r,
+                                            '[%s]_' % new_r)
+                lines[i] = lines[i].replace('.. [%s]' % r,
+                                            '.. [%s]' % new_r)
 
 
 def _is_cite_in_numpydoc_docstring(citation_node):
@@ -166,21 +154,17 @@ def mangle_docstrings(app, what, name, obj, options, lines):
            }
 
     cfg.update(options or {})
-    u_NL = sixu('\n')
+    u_NL = '\n'
     if what == 'module':
         # Strip top title
         pattern = '^\\s*[#*=]{4,}\\n[a-z0-9 -]+\\n[#*=]{4,}\\s*'
-        title_re = re.compile(sixu(pattern), re.I | re.S)
-        lines[:] = title_re.sub(sixu(''), u_NL.join(lines)).split(u_NL)
+        title_re = re.compile(pattern, re.I | re.S)
+        lines[:] = title_re.sub('', u_NL.join(lines)).split(u_NL)
     else:
         try:
             doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg,
                                  builder=app.builder)
-            if sys.version_info[0] >= 3:
-                doc = str(doc)
-            else:
-                doc = unicode(doc)
-            lines[:] = doc.split(u_NL)
+            lines[:] = str(doc).split(u_NL)
         except:
             logger.error('[numpydoc] While processing docstring for %r', name)
             raise
@@ -188,11 +172,11 @@ def mangle_docstrings(app, what, name, obj, options, lines):
     if (app.config.numpydoc_edit_link and hasattr(obj, '__name__') and
             obj.__name__):
         if hasattr(obj, '__module__'):
-            v = dict(full_name=sixu("%s.%s") % (obj.__module__, obj.__name__))
+            v = dict(full_name="%s.%s" % (obj.__module__, obj.__name__))
         else:
             v = dict(full_name=obj.__name__)
-        lines += [sixu(''), sixu('.. htmlonly::'), sixu('')]
-        lines += [sixu('    %s') % x for x in
+        lines += ['', '.. htmlonly::', '']
+        lines += ['    %s' % x for x in
                   (app.config.numpydoc_edit_link % v).split("\n")]
 
     # call function to replace reference numbers so that there are no
@@ -218,8 +202,8 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
     doc = get_doc_object(obj, config={'show_class_members': False})
     sig = doc['Signature'] or getattr(obj, '__text_signature__', None)
     if sig:
-        sig = re.sub(sixu("^[^(]*"), sixu(""), sig)
-        return sig, sixu('')
+        sig = re.sub("^[^(]*", "", sig)
+        return sig, ''
 
 
 def setup(app, get_doc_object_=get_doc_object):

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1,6 +1,4 @@
 # -*- encoding:utf-8 -*-
-from __future__ import division, absolute_import, print_function
-
 from collections import namedtuple
 from copy import deepcopy
 import re
@@ -22,12 +20,6 @@ from numpydoc.docscrape_sphinx import (SphinxDocString, SphinxClassDoc,
                                        SphinxFunctionDoc, get_doc_object)
 from pytest import raises as assert_raises
 from pytest import warns as assert_warns
-
-
-if sys.version_info[0] >= 3:
-    sixu = lambda s: s
-else:
-    sixu = lambda s: unicode(s, 'unicode_escape')
 
 
 doc_txt = '''\

--- a/numpydoc/tests/test_numpydoc.py
+++ b/numpydoc/tests/test_numpydoc.py
@@ -1,6 +1,4 @@
 # -*- encoding:utf-8 -*-
-from __future__ import division, absolute_import, print_function
-
 from copy import deepcopy
 from numpydoc.numpydoc import mangle_docstrings
 from numpydoc.xref import DEFAULT_LINKS

--- a/numpydoc/tests/test_xref.py
+++ b/numpydoc/tests/test_xref.py
@@ -1,6 +1,4 @@
 # -*- encoding:utf-8 -*-
-from __future__ import division, absolute_import, print_function
-
 from numpydoc.xref import make_xref
 
 xref_aliases = {

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import sys
 import os
 
@@ -9,8 +7,8 @@ from distutils.core import setup
 
 from numpydoc import __version__ as version
 
-if sys.version_info[:2] < (2, 7) or (3, 0) <= sys.version_info[0:2] < (3, 4):
-    raise RuntimeError("Python version 2.7 or >= 3.4 required.")
+if sys.version_info < (3, 5):
+    raise RuntimeError("Python version >= 3.5 required.")
 
 
 def read(fname):
@@ -36,18 +34,18 @@ setup(
                  "License :: OSI Approved :: BSD License",
                  "Topic :: Documentation",
                  "Programming Language :: Python",
-                 "Programming Language :: Python :: 2",
-                 "Programming Language :: Python :: 2.7",
                  "Programming Language :: Python :: 3",
-                 "Programming Language :: Python :: 3.4",
                  "Programming Language :: Python :: 3.5",
-                 "Programming Language :: Python :: 3.6"],
+                 "Programming Language :: Python :: 3.6",
+                 "Programming Language :: Python :: 3.7",
+                 ],
     keywords="sphinx numpy",
     author="Pauli Virtanen and others",
     author_email="pav@iki.fi",
     url="https://numpydoc.readthedocs.io",
     license="BSD",
     install_requires=["sphinx >= 1.6.5", 'Jinja2>=2.3'],
+    python_requires=">=3.5",
     package_data={'numpydoc': [
         'tests/test_*.py',
         'tests/tinybuild/Makefile',


### PR DESCRIPTION
Closes https://github.com/numpy/numpydoc/issues/235

Should also close https://github.com/numpy/numpydoc/issues/163

For when that issue receives positive feedback. If not now then later.