### PR TITLE
Adding --validate option __main__ and run new validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ script:
   - pytest -v --pyargs numpydoc
   # Making sure the command line options work
   - python -m numpydoc numpydoc.tests.test_main._capture_stdout
-  - ! python -m numpydoc numpydoc.tests.test_main._invalid_docstring
+  - echo '! python -m numpydoc numpydoc.tests.test_main._invalid_docstring' | bash
   - python -m numpydoc --validate numpydoc.tests.test_main._capture_stdout
-  - ! python -m numpydoc --validate numpydoc.tests.test_main._docstring_with_errors
+  - echo '! python -m numpydoc --validate numpydoc.tests.test_main._docstring_with_errors' | bash
   # Build documentation
   - |
     cd ../doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,12 @@ script:
     cd dist
     pip install numpydoc* -v
   - pytest -v --pyargs numpydoc
+  # Making sure the command line options work
+  - python -m numpydoc numpydoc.tests.test_main._capture_stdout
+  - ! python -m numpydoc numpydoc.tests.test_main._invalid_docstring
+  - python -m numpydoc --validate numpydoc.tests.test_main._capture_stdout
+  - ! python -m numpydoc --validate numpydoc.tests.test_main._docstring_with_errors
+  # Build documentation
   - |
     cd ../doc
     make SPHINXOPTS=$SPHINXOPTS html

--- a/doc/validation.rst
+++ b/doc/validation.rst
@@ -2,11 +2,16 @@
 Validating NumpyDoc docstrings
 ==============================
 
-One tool for validating docstrings is to see how an object's dosctring
-translates to Restructured Text.  Using numpydoc as a command-line tool
-facilitates this. For example to see the Restructured Text generated
-for ``numpy.ndarray``, use:
+To see the Restructured Text generated for an object, the ``numpydoc`` module
+can be called. For example, to do it for ``numpy.ndarray``, use:
 
 .. code-block:: bash
 
     $ python -m numpydoc numpy.ndarray
+
+This will validate that the docstring can be built.
+
+For an exhaustive validation of the formatting of the docstring, use the
+``--validate`` parameter. This will report the errors detected, such as
+incorrect capitalization, wrong order of the sections, and many other
+issues.

--- a/numpydoc/__init__.py
+++ b/numpydoc/__init__.py
@@ -1,3 +1,7 @@
+"""
+This package provides the numpydoc Sphinx extension for handling docstrings
+formatted according to the NumPy documentation format.
+"""
 __version__ = '1.0.0.dev0'
 
 

--- a/numpydoc/__main__.py
+++ b/numpydoc/__main__.py
@@ -1,32 +1,19 @@
+"""
+Implementing `python -m numpydoc` functionality.
+"""
 import sys
 import argparse
-import importlib
 import ast
 
 from .docscrape_sphinx import get_doc_object
-from .validate import validate
+from .validate import validate, Docstring
 
 
-def render_object(import_path, config):
+def render_object(import_path, config=None):
     """Test numpydoc docstring generation for a given object"""
-    parts = import_path.split('.')
-
-    for split_point in range(len(parts), 0, -1):
-        try:
-            path = '.'.join(parts[:split_point])
-            obj = importlib.import_module(path)
-        except ImportError:
-            continue
-        break
-    else:
-        raise ImportError('Could not resolve {!r} to an importable object'
-                          ''.format(import_path))
-
-    for part in parts[split_point:]:
-        obj = getattr(obj, part)
-
-    print(get_doc_object(obj, config=dict(config or [])))
-
+    # TODO: Move Docstring._load_obj to a better place than validate
+    print(get_doc_object(Docstring(import_path).obj,
+                         config=dict(config or [])))
     return 0
 
 

--- a/numpydoc/__main__.py
+++ b/numpydoc/__main__.py
@@ -1,13 +1,45 @@
+import sys
 import argparse
 import importlib
 import ast
 
 from .docscrape_sphinx import get_doc_object
+from .validate import validate
 
 
-def main(argv=None):
+def render_object(import_path, config):
     """Test numpydoc docstring generation for a given object"""
+    parts = import_path.split('.')
 
+    for split_point in range(len(parts), 0, -1):
+        try:
+            path = '.'.join(parts[:split_point])
+            obj = importlib.import_module(path)
+        except ImportError:
+            continue
+        break
+    else:
+        raise ImportError('Could not resolve {!r} to an importable object'
+                          ''.format(import_path))
+
+    for part in parts[split_point:]:
+        obj = getattr(obj, part)
+
+    print(get_doc_object(obj, config=dict(config or [])))
+
+    return 0
+
+
+def validate_object(import_path):
+    exit_status = 0
+    results = validate(import_path)
+    for err_code, err_desc in results["errors"]:
+        exit_status += 1
+        print(':'.join([import_path, err_code, err_desc]))
+    return exit_status
+
+
+if __name__ == '__main__':
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument('import_path', help='e.g. numpy.ndarray')
 
@@ -20,25 +52,13 @@ def main(argv=None):
                     action='append',
                     help='key=val where val will be parsed by literal_eval, '
                          'e.g. -c use_plots=True. Multiple -c can be used.')
-    args = ap.parse_args(argv)
+    ap.add_argument('--validate', action='store_true',
+                    help='validate the object and report errors')
+    args = ap.parse_args()
 
-    parts = args.import_path.split('.')
-
-    for split_point in range(len(parts), 0, -1):
-        try:
-            path = '.'.join(parts[:split_point])
-            obj = importlib.import_module(path)
-        except ImportError:
-            continue
-        break
+    if args.validate:
+        exit_code = validate_object(args.import_path)
     else:
-        raise ImportError('Could not resolve {!r} to an importable object'
-                          ''.format(args.import_path))
+        exit_code = render_object(args.import_path, args.config)
 
-    for part in parts[split_point:]:
-        obj = getattr(obj, part)
-
-    print(get_doc_object(obj, config=dict(args.config or [])))
-
-if __name__ == '__main__':
-    main()
+    sys.exit(exit_code)

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -152,7 +152,7 @@ class Docstring:
         >>> Docstring._load_obj('datetime.datetime')
         <class 'datetime.datetime'>
         """
-        for maxsplit in range(1, name.count(".") + 1):
+        for maxsplit in range(0, name.count(".") + 1):
             module, *func_parts = name.rsplit(".", maxsplit)
             try:
                 obj = importlib.import_module(module)


### PR DESCRIPTION
Closes #213

`python -m numpydoc` keeps existing functionality, but when called with `--validate` runs the new validation:

```
(sklearn-dev) [mgarcia@xps numpydoc]$ PYTHONPATH=. python -m numpydoc --validate sklearn.linear_model.LinearRegression
sklearn.linear_model.LinearRegression:GL02:Closing quotes should be placed in the line after the last text in the docstring (do not close the quotes in the same line as the text, or leave a blank line between the last text and the quotes)
sklearn.linear_model.LinearRegression:GL03:Double line break found; please use only one blank line to separate sections or paragraphs, and do not leave blank lines at the end of docstrings
sklearn.linear_model.LinearRegression:ES01:No extended summary found
sklearn.linear_model.LinearRegression:PR06:Parameter "fit_intercept" type should use "bool" instead of "boolean"
sklearn.linear_model.LinearRegression:PR08:Parameter "fit_intercept" description should start with a capital letter
sklearn.linear_model.LinearRegression:PR06:Parameter "normalize" type should use "bool" instead of "boolean"
sklearn.linear_model.LinearRegression:PR06:Parameter "copy_X" type should use "bool" instead of "boolean"
sklearn.linear_model.LinearRegression:SA01:See Also section not found
sklearn.linear_model.LinearRegression:EX01:No examples section found
```