### PR TITLE
Delay import of Sphinx

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -11,7 +11,6 @@ from collections.abc import Callable, Mapping
 import copy
 import sys
 
-from sphinx.ext.autodoc import ALL
 
 def strip_blank_lines(l):
     "Remove leading and trailing blank lines from a list of lines"
@@ -617,6 +616,8 @@ class ClassDoc(NumpyDocString):
 
     def __init__(self, cls, doc=None, modulename='', func_doc=FunctionDoc,
                  config={}):
+        from sphinx.ext.autodoc import ALL
+
         if not inspect.isclass(cls) and cls is not None:
             raise ValueError("Expected a class or None, but got %r" % cls)
         self._cls = cls

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -11,10 +11,6 @@ from collections.abc import Callable, Mapping
 import copy
 import sys
 
-if 'sphinx' in sys.modules:
-    from sphinx.ext.autodoc import ALL
-else:
-    ALL = object()
 
 def strip_blank_lines(l):
     "Remove leading and trailing blank lines from a list of lines"
@@ -623,6 +619,11 @@ class ClassDoc(NumpyDocString):
         if not inspect.isclass(cls) and cls is not None:
             raise ValueError("Expected a class or None, but got %r" % cls)
         self._cls = cls
+
+        if 'sphinx' in sys.modules:
+            from sphinx.ext.autodoc import ALL
+        else:
+            ALL = object()
 
         self.show_inherited_members = config.get(
                     'show_inherited_class_members', True)

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -11,6 +11,10 @@ from collections.abc import Callable, Mapping
 import copy
 import sys
 
+if 'sphinx' in sys.modules:
+    from sphinx.ext.autodoc import ALL
+else:
+    ALL = object()
 
 def strip_blank_lines(l):
     "Remove leading and trailing blank lines from a list of lines"
@@ -616,8 +620,6 @@ class ClassDoc(NumpyDocString):
 
     def __init__(self, cls, doc=None, modulename='', func_doc=FunctionDoc,
                  config={}):
-        from sphinx.ext.autodoc import ALL
-
         if not inspect.isclass(cls) and cls is not None:
             raise ValueError("Expected a class or None, but got %r" % cls)
         self._cls = cls


### PR DESCRIPTION
`from numpydoc.docscrape import FunctionDoc` takes ~3.5 s on my Windows workstation because importing `Sphinx` triggers the use of `pkg_resources`, which is excruciatingly slow if many Python packages are installed.

AFAICT, `FunctionDoc`  does not require Sphinx. 

https://github.com/pypa/setuptools/issues/510