### PR TITLE
Add missing headings to code examples

### DIFF
--- a/doc/format.rst
+++ b/doc/format.rst
@@ -338,7 +338,6 @@ The sections of a function's docstring are:
     
       Notes
       -----
-
       The FFT is a fast implementation of the discrete Fourier transform:
 
       .. math:: X(e^{j\omega } ) = x(n)e^{ - j\omega n}

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -335,6 +335,9 @@ The sections of a function's docstring are:
     code, possibly including a discussion of the algorithm. This
     section may include mathematical equations, written in
     `LaTeX <https://www.latex-project.org/>`_ format::
+    
+      Notes
+      -----
 
       The FFT is a fast implementation of the discrete Fourier transform:
 
@@ -419,6 +422,8 @@ The sections of a function's docstring are:
     blank lines. Comments explaining the examples should have blank
     lines both above and below them::
 
+      Examples
+      --------
       >>> np.add(1, 2)
       3
 


### PR DESCRIPTION
The Notes and Examples sections have code examples showing what can go in the section, and unlike all the other sections with examples didn't show the heading.

This lead to some confusion when reading the notes section between that and `.. note:`