### PR TITLE
MAINT,STY: Upgrade to bionic, and change style similar to NumPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,34 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 language: python
-dist: xenial
-sudo: false
-matrix:
+group: travis_latest
+os: linux
+dist: bionic
+
+addons:
+  apt:
+    packages:
+      - texlive
+      - texlive-latex-extra
+      - latexmk
+      - dvipng
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+
+jobs:
   include:
     - python: 3.7
     - python: 3.6
       env: SPHINX_SPEC="==2.1.0" SPHINXOPTS=""
     - python: 3.5
       env: SPHINX_SPEC="==1.6.5" SPHINXOPTS=""
-cache:
-  directories:
-    - $HOME/.cache/pip
+
 before_install:
-  - sudo apt-get install texlive texlive-latex-extra latexmk dvipng
-  - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
+  - pip install --upgrade pip setuptools  # Ensure there is `wheel` support
   - pip install pytest pytest-cov pydocstyle numpy matplotlib sphinx${SPHINX_SPEC} codecov
+
 script:
   - |
     python setup.py sdist
@@ -34,6 +46,7 @@ script:
     cd ../doc
     make SPHINXOPTS=$SPHINXOPTS html
     make SPHINXOPTS=$SPHINXOPTS latexpdf
+
 after_script:
   - |
     cd ../dist


### PR DESCRIPTION
This PR makes this Travis CI configuration file similar to [NumPy's](https://github.com/numpy/numpy/blob/master/.travis.yml), specifically:

* Upgrade `dist` from `xenial` to `bionic`
* Use `group: travis_latest` ([more info](https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images))
* Remove unused `sudo` command
* Rename `matrix` to `jobs` (former is an alias)
* Rewrite YAML version of "sudo apt-get install ..."
* Add newline between sections