### PR TITLE
MAINT: clean-up unused objects

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -137,7 +137,7 @@ if not os.path.isdir(themedir):
 html_theme = 'scipy'
 html_theme_path = [themedir]
 
-if 'scipyorg' in tags:
+if 'scipyorg' in tags:  # noqa: F821
     # Build for the scipy.org website
     html_theme_options = {
         "edit_link": True,

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -595,7 +595,6 @@ class FunctionDoc(NumpyDocString):
         out = ''
 
         func, func_name = self.get_func()
-        signature = self['Signature'].replace('*', r'\*')
 
         roles = {'func': 'function',
                  'meth': 'method'}

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -2,7 +2,6 @@
 from collections import namedtuple
 from copy import deepcopy
 import re
-import sys
 import textwrap
 import warnings
 
@@ -242,26 +241,6 @@ def test_sent():
         assert arg_type == arg_type_
         assert desc[0].startswith('The number of')
         assert desc[0].endswith(end)
-
-
-def test_returnyield():
-    doc_text = """
-Test having returns and yields.
-
-Returns
--------
-int
-    The number of apples.
-
-Yields
-------
-a : int
-    The number of apples.
-b : int
-    The number of bananas.
-
-"""
-    assert_raises(ValueError, NumpyDocString, doc_text)
 
 
 def test_returnyield():
@@ -859,7 +838,7 @@ def test_see_also_print():
 def test_see_also_trailing_comma_warning():
     warnings.filterwarnings('error')
     with assert_warns(Warning, match='Unexpected comma or period after function list at index 43 of line .*'):
-        doc6 = NumpyDocString(
+        NumpyDocString(
             """
             z(x,theta)
 

--- a/numpydoc/tests/test_numpydoc.py
+++ b/numpydoc/tests/test_numpydoc.py
@@ -42,25 +42,28 @@ A top section before
 .. autoclass:: str
     '''
     lines = s.split('\n')
-    doc = mangle_docstrings(MockApp(), 'class', 'str', str, {}, lines)
+    mangle_docstrings(MockApp(), 'class', 'str', str, {}, lines)
     assert 'rpartition' in [x.strip() for x in lines]
 
     lines = s.split('\n')
-    doc = mangle_docstrings(MockApp(), 'class', 'str', str, {'members': ['upper']}, lines)
+    mangle_docstrings(
+        MockApp(), 'class', 'str', str, {'members': ['upper']}, lines)
     assert 'rpartition' not in [x.strip() for x in lines]
     assert 'upper' in [x.strip() for x in lines]
 
     lines = s.split('\n')
-    doc = mangle_docstrings(MockApp(), 'class', 'str', str, {'exclude-members': ALL}, lines)
+    mangle_docstrings(
+        MockApp(), 'class', 'str', str, {'exclude-members': ALL}, lines)
     assert 'rpartition' not in [x.strip() for x in lines]
     assert 'upper' not in [x.strip() for x in lines]
 
     lines = s.split('\n')
-    doc = mangle_docstrings(MockApp(), 'class', 'str', str,
-                            {'exclude-members': ['upper']}, lines)
+    mangle_docstrings(
+        MockApp(), 'class', 'str', str, {'exclude-members': ['upper']}, lines)
     assert 'rpartition' in [x.strip() for x in lines]
     assert 'upper' not in [x.strip() for x in lines]
 
 
 if __name__ == "__main__":
     import pytest
+    pytest.main()


### PR DESCRIPTION
* F401: Add pytest.main() or clean-up unused import
* F811: remove second identical 'test_returnyield' function
* F821: 'tags' is a special object from sphinx-build; mark with `noqa`
* F841: clean-up unused local variables

Found with `flake8 --select=F401,F811,F821,F841`