### PR TITLE
Disable escaping "*" on signature

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -564,7 +564,7 @@ class FunctionDoc(NumpyDocString):
             if func is None:
                 raise ValueError("No function or docstring given")
             doc = inspect.getdoc(func) or ''
-        NumpyDocString.__init__(self, doc)
+        NumpyDocString.__init__(self, doc, config)
 
         if not self['Signature'] and func is not None:
             func, func_name = self.get_func()
@@ -578,7 +578,7 @@ class FunctionDoc(NumpyDocString):
                     else:
                         argspec = inspect.getargspec(func)
                     signature = inspect.formatargspec(*argspec)
-                signature = '%s%s' % (func_name, signature.replace('*', r'\*'))
+                signature = '%s%s' % (func_name, signature)
             except TypeError:
                 signature = '%s()' % func_name
             self['Signature'] = signature

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -720,7 +720,7 @@ def test_escape_stars():
         pass
 
     fdoc = FunctionDoc(func=my_func)
-    assert fdoc['Signature'] == r'my_func(a, b, \*\*kwargs)'
+    assert fdoc['Signature'] == 'my_func(a, b, **kwargs)'
 
 
 doc4 = NumpyDocString(

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -47,7 +47,7 @@ def test_MyClass(sphinx_app):
         html = fid.read()
     # escaped * chars should no longer be preceded by \'s,
     # if we see a \* in the output we know it's incorrect:
-    assert r'\*' in html  # XXX should be "not in", bug!
+    assert r'\*' not in html
     # "self" should not be in the parameter list for the class:
     assert 'self,' in html   # XXX should be "not in", bug!
     # check xref was embedded properly (dict should link using xref):


### PR DESCRIPTION
On handling autodoc-process-signature event, it's not needed to
escape "*" characters.  The escaping is mainly allowed for
highlighting feature of editors.  So it's not necessary for
generating contents by autodoc.

In addition, since Sphinx-3.0, the escaping is not recommended by
default (see strip_signature_backslash)

refs: https://github.com/sphinx-doc/sphinx/issues/7439