### PR TITLE
ENH: Add args and kwargs to example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/html/index.html
+          circleci-jobs: build_docs

--- a/doc/example.py
+++ b/doc/example.py
@@ -35,7 +35,7 @@ import matplotlib.pyplot as plt
 # numpy module itself, unabbreviated.
 
 
-def foo(var1, var2, long_var_name='hi'):
+def foo(var1, var2, *args, long_var_name='hi', **kwargs):
     r"""Summarize the function in one line.
 
     Several sentences providing an extended description. Refer to
@@ -51,8 +51,12 @@ def foo(var1, var2, long_var_name='hi'):
         The type above can either refer to an actual Python type
         (e.g. ``int``), or describe the type of the variable in more
         detail, e.g. ``(N,) ndarray`` or ``array_like``.
+    *args : iterable
+        Other arguments.
     long_var_name : {'hi', 'ho'}, optional
         Choices in brackets, default first when optional.
+    **kwargs : dict
+        Keyword arguments.
 
     Returns
     -------


### PR DESCRIPTION
I wanted to view the results of #256, but our example does not have `*args, **kwargs` in it. This does that, plus uses circleci-artifacts-redirector-action to make a more direct link to the artifacts.

@rgommers @jnothman can you also enable GitHub actions for this repo? I don't have permissions to do it.