### PR TITLE
TST: Add inherited method

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -168,7 +168,7 @@ def mangle_docstrings(app, what, name, obj, options, lines):
             doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg,
                                  builder=app.builder)
             lines[:] = str(doc).split(u_NL)
-        except:
+        except Exception:
             logger.error('[numpydoc] While processing docstring for %r', name)
             raise
 

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -27,7 +27,8 @@ def sphinx_app(tmpdir_factory):
     # https://github.com/sphinx-doc/sphinx/issues/5038
     with docutils_namespace():
         app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
-                     buildername='html')
+                     buildername='html', warningiserror=True,
+                     keep_going=True)
         # need to build within the context manager
         # for automodule and backrefs to work
         app.build(False, [])
@@ -46,6 +47,9 @@ def test_MyClass(sphinx_app):
                          'numpydoc_test_module.MyClass.html')
     with open(class_html, 'r') as fid:
         html = fid.read()
+    # ensure that no autodoc weirdness ($) occurs
+    assert '$self' not in html
+    assert 'Inherit a method' in html
     # escaped * chars should no longer be preceded by \'s,
     # if we see a \* in the output we know it's incorrect:
     assert r'\*' not in html
@@ -77,7 +81,7 @@ def test_reference(sphinx_app):
         ["generated", "numpydoc_test_module.MyClass.html"],
     ]
 
-    expected_lengths = [3, 1, 1]
+    expected_lengths = [1, 1, 1]
 
     for html_file, expected_length in zip(html_files, expected_lengths):
         html_file = op.join(out_dir, *html_file)

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -53,7 +53,7 @@ def test_MyClass(sphinx_app):
         html = fid.read()
     # ensure that no autodoc weirdness ($) occurs
     assert '$self' not in html
-    assert 'Inherit a method' in html
+    assert '__init__' in html  # inherited
     # escaped * chars should no longer be preceded by \'s,
     # if we see a \* in the output we know it's incorrect:
     assert r'\*' not in html

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -1,8 +1,10 @@
+from distutils.version import LooseVersion
 import os.path as op
 import re
 import shutil
 
 import pytest
+import sphinx
 from sphinx.application import Sphinx
 from sphinx.util.docutils import docutils_namespace
 
@@ -25,10 +27,12 @@ def sphinx_app(tmpdir_factory):
     toctrees_dir = op.join(temp_dir, '_build', 'toctrees')
     # Avoid warnings about re-registration, see:
     # https://github.com/sphinx-doc/sphinx/issues/5038
+    kwargs = dict()
+    if LooseVersion(sphinx.__version__) >= LooseVersion('1.8'):
+        kwargs.update(warningiserror=True, keep_going=True)
     with docutils_namespace():
         app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
-                     buildername='html', warningiserror=True,
-                     keep_going=True)
+                     buildername='html', **kwargs)
         # need to build within the context manager
         # for automodule and backrefs to work
         app.build(False, [])

--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -1274,7 +1274,10 @@ class TestValidator:
         ],
     )
     def test_bad_docstrings(self, capsys, klass, func, msgs):
-        result = validate_one(self._import_path(klass=klass, func=func))
+        with pytest.warns(None) as w:
+            result = validate_one(self._import_path(klass=klass, func=func))
+        if len(w):
+            assert all('Unknown section' in str(ww.message) for ww in w)
         for msg in msgs:
             assert msg in " ".join(err[1] for err in result["errors"])
 

--- a/numpydoc/tests/tinybuild/Makefile
+++ b/numpydoc/tests/tinybuild/Makefile
@@ -5,7 +5,7 @@ clean:
 	rm -rf generated/
 
 html:
-	sphinx-build -b html -d _build/doctrees . _build/html
+	sphinx-build -nWT --keep-going -b html -d _build/doctrees . _build/html
 
 show:
 	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/_build/html/index.html')"

--- a/numpydoc/tests/tinybuild/conf.py
+++ b/numpydoc/tests/tinybuild/conf.py
@@ -11,12 +11,15 @@ extensions = [
 ]
 project = 'numpydoc_test_module'
 autosummary_generate = True
+autodoc_default_options = {'inherited-members': None}
 source_suffix = '.rst'
 master_doc = 'index'
-exclude_patterns = ['_build']
+templates_path = ['_templates']
+exclude_patterns = ['_build', '_templates']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
 }
 nitpicky = True
 highlight_language = 'python3'
+numpydoc_class_members_toctree = False
 numpydoc_xref_param_type = True

--- a/numpydoc/tests/tinybuild/conf.py
+++ b/numpydoc/tests/tinybuild/conf.py
@@ -14,8 +14,7 @@ autosummary_generate = True
 autodoc_default_options = {'inherited-members': None}
 source_suffix = '.rst'
 master_doc = 'index'
-templates_path = ['_templates']
-exclude_patterns = ['_build', '_templates']
+exclude_patterns = ['_build']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
 }

--- a/numpydoc/tests/tinybuild/index.rst
+++ b/numpydoc/tests/tinybuild/index.rst
@@ -2,4 +2,6 @@ numpydoc_test_module
 ====================
 
 .. automodule:: numpydoc_test_module
-    :members:
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/numpydoc/tests/tinybuild/numpydoc_test_module.py
+++ b/numpydoc/tests/tinybuild/numpydoc_test_module.py
@@ -13,13 +13,19 @@ Reference [1]_
 References
 ----------
 .. [1] https://numpydoc.readthedocs.io
-
 """
 
 __all__ = ['MyClass', 'my_function']
 
 
-class MyClass(object):
+class _MyBaseClass(object):
+
+    def inherited(self):
+        """Inherit a method."""
+        pass
+
+
+class MyClass(_MyBaseClass):
     """A class.
 
     Reference [2]_
@@ -40,8 +46,7 @@ class MyClass(object):
         pass
 
     def example(self):
-        """Exampel function
-        """
+        """Example function."""
         pass
 
 

--- a/numpydoc/tests/tinybuild/numpydoc_test_module.py
+++ b/numpydoc/tests/tinybuild/numpydoc_test_module.py
@@ -36,7 +36,7 @@ class MyClass(object):
     """
 
     def example(self):
-        """Example function."""
+        """Example method."""
         pass
 
 

--- a/numpydoc/tests/tinybuild/numpydoc_test_module.py
+++ b/numpydoc/tests/tinybuild/numpydoc_test_module.py
@@ -18,14 +18,7 @@ References
 __all__ = ['MyClass', 'my_function']
 
 
-class _MyBaseClass(object):
-
-    def inherited(self):
-        """Inherit a method."""
-        pass
-
-
-class MyClass(_MyBaseClass):
+class MyClass(object):
     """A class.
 
     Reference [2]_
@@ -41,9 +34,6 @@ class MyClass(_MyBaseClass):
     ----------
     .. [2] https://numpydoc.readthedocs.io
     """
-
-    def __init__(self, *args, **kwargs):
-        pass
 
     def example(self):
         """Example function."""

--- a/numpydoc/tests/tinybuild/numpydoc_test_module.py
+++ b/numpydoc/tests/tinybuild/numpydoc_test_module.py
@@ -35,7 +35,7 @@ class MyClass(object):
     .. [2] https://numpydoc.readthedocs.io
     """
 
-    def example(self):
+    def example(self, x):
         """Example method."""
         pass
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,8 @@
 addopts =
     --showlocals --doctest-modules -ra --cov-report= --cov=numpydoc
     --junit-xml=junit-results.xml --ignore=doc/conf.py
+junit_family = xunit2
 filterwarnings =
     ignore:'U' mode is deprecated:DeprecationWarning
+    ignore:.*sphinx\.util\.smartypants is deprecated.*:
     ignore:Using or importing the ABCs.*:DeprecationWarning


### PR DESCRIPTION
A number of mostly small tweaks:

1. Fixes a minor typo
2. Adds an inherited method in `test_full.py` that hopefully will show (or be easily modified to show) the bug in #221 with `$self`
3. Cleans up warnings in `pytest`
4. Fixes a bare `except`
5. Cleans up warnings in `tinybuild`
6. Runs `tinybuild` with warnings-as-errors

Should make things hopefully more robust. Might take a few iterations to get right depending on which Sphinx versions we support (I'll let the CIs tell me).