### PR TITLE
FIX: Get doc of actual class in test

### DIFF
--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -828,8 +828,7 @@ def test_see_also_print():
         """
         pass
 
-    obj = Dummy()
-    s = str(FunctionDoc(obj, role='func'))
+    s = str(FunctionDoc(Dummy, role='func'))
     assert(':func:`func_a`, :func:`func_b`' in s)
     assert('    some relationship' in s)
     assert(':func:`func_d`' in s)


### PR DESCRIPTION
Closes #261 

Seems to be caused by https://bugs.python.org/issue40257 / https://docs.python.org/3.9/whatsnew/3.9.html#changes-in-the-python-api. I assume it's actually reasonable / more correct to look at the doc of the class, rather than an instance of the class. @opoplawski can you see if it indeed fixes it for you? Using `deadsnakes` ppa on 20.04 it seems to work for me...