### PR TITLE
MAINT: Bump to 1.1.0.dev0

### DIFF
--- a/numpydoc/__init__.py
+++ b/numpydoc/__init__.py
@@ -2,7 +2,7 @@
 This package provides the numpydoc Sphinx extension for handling docstrings
 formatted according to the NumPy documentation format.
 """
-__version__ = '1.0.0'
+__version__ = '1.1.0.dev0'
 
 
 def setup(app, *args, **kwargs):


### PR DESCRIPTION
1.0.0 is on PyPI, time to bump to 1.1.0.dev0