### PR TITLE
DEV: Add testing requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,12 @@ setup(
     license="BSD",
     install_requires=["sphinx >= 1.6.5", 'Jinja2>=2.3'],
     python_requires=">=3.5",
+    extras_require={
+        "testing": [
+            req for req in read('test_requirements.txt').split('\n')
+            if not req.startswith('#')
+        ],
+    },
     package_data={'numpydoc': [
         'tests/test_*.py',
         'tests/tinybuild/Makefile',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+matplotlib


### PR DESCRIPTION
Adds testing requirements to `test_requirements.txt` (following the pattern in numpy/numpy) to aid developers in setting up a development environment for numpydoc. 

 * bf87dc7 adds the necessary dependencies for running the test suite to `test_requirements.txt` so that they can be installed (e.g. with `pip install -r test_requirements.txt`)
 * 64d351d adds `test_requirements.txt` to `setup.py` via the `extra_requires` option, providing an additional convenience for pip users (e.g. `pip install -e .[testing]`)