### PR TITLE
BUG: Connect to earlier event

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -218,7 +218,7 @@ def setup(app, get_doc_object_=get_doc_object):
 
     app.setup_extension('sphinx.ext.autosummary')
 
-    app.connect('builder-inited', update_config)
+    app.connect('config-inited', update_config)
     app.connect('autodoc-process-docstring', mangle_docstrings)
     app.connect('autodoc-process-signature', mangle_signature)
     app.connect('doctree-read', relabel_references)
@@ -244,17 +244,19 @@ def setup(app, get_doc_object_=get_doc_object):
     return metadata
 
 
-def update_config(app):
+def update_config(app, config=None):
     """Update the configuration with default values."""
+    if config is None:  # only really needed for testing
+        config = app.config
     # Do not simply overwrite the `app.config.numpydoc_xref_aliases`
     # otherwise the next sphinx-build will compare the incoming values (without
     # our additions) to the old values (with our additions) and trigger
     # a full rebuild!
-    numpydoc_xref_aliases_complete = deepcopy(app.config.numpydoc_xref_aliases)
+    numpydoc_xref_aliases_complete = deepcopy(config.numpydoc_xref_aliases)
     for key, value in DEFAULT_LINKS.items():
         if key not in numpydoc_xref_aliases_complete:
             numpydoc_xref_aliases_complete[key] = value
-    app.config.numpydoc_xref_aliases_complete = numpydoc_xref_aliases_complete
+    config.numpydoc_xref_aliases_complete = numpydoc_xref_aliases_complete
 
 
 # ------------------------------------------------------------------------------

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -28,6 +28,7 @@ from docutils.nodes import citation, Text, section, comment, reference
 import sphinx
 from sphinx.addnodes import pending_xref, desc_content
 from sphinx.util import logging
+from sphinx.errors import ExtensionError
 
 if sphinx.__version__ < '1.6.5':
     raise RuntimeError("Sphinx 1.6.5 or newer is required")
@@ -218,7 +219,13 @@ def setup(app, get_doc_object_=get_doc_object):
 
     app.setup_extension('sphinx.ext.autosummary')
 
-    app.connect('config-inited', update_config)
+    # Once we bump our Sphinx requirement higher (1.7 or 1.8?)
+    # we can just connect to config-inited
+    try:
+        app.connect('config-inited', update_config)
+    except ExtensionError:
+        app.connect('builder-inited', update_config)
+
     app.connect('autodoc-process-docstring', mangle_docstrings)
     app.connect('autodoc-process-signature', mangle_signature)
     app.connect('doctree-read', relabel_references)
@@ -246,7 +253,7 @@ def setup(app, get_doc_object_=get_doc_object):
 
 def update_config(app, config=None):
     """Update the configuration with default values."""
-    if config is None:  # only really needed for testing
+    if config is None:  # needed for testing and old Sphinx
         config = app.config
     # Do not simply overwrite the `app.config.numpydoc_xref_aliases`
     # otherwise the next sphinx-build will compare the incoming values (without


### PR DESCRIPTION
Closes #268.

Another option might be to still connect to `build-inited` but with a lower priority number, but in theory connecting to `config-inited` should be okay (and arguably cleaner anyway).