### PR TITLE
MAINT: Suggestions from reviewing test suite

### DIFF
--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -278,7 +278,7 @@ That should break...
     assert_raises(ValueError, NumpyDocString, doc_text)
 
     # if we have a numpydoc object, we know where the error came from
-    class Dummy(object):
+    class Dummy:
         """
         Dummy class.
 
@@ -817,7 +817,7 @@ def test_see_also_parse_error():
 
 
 def test_see_also_print():
-    class Dummy(object):
+    class Dummy:
         """
         See Also
         --------
@@ -858,7 +858,7 @@ Mope
 This should be ignored and warned about
 """
 
-    class BadSection(object):
+    class BadSection:
         """Class with bad section.
 
         Nope
@@ -995,7 +995,7 @@ def test_use_blockquotes():
 
 def test_class_members():
 
-    class Dummy(object):
+    class Dummy:
         """
         Dummy class.
 
@@ -1011,7 +1011,7 @@ def test_class_members():
             """Spammity index"""
             return 0.95
 
-        class Ignorable(object):
+        class Ignorable:
             """local class, to be ignored"""
             pass
 
@@ -1327,7 +1327,7 @@ def test_templated_sections():
 def test_nonstandard_property():
     # test discovery of a property that does not satisfy isinstace(.., property)
 
-    class SpecialProperty(object):
+    class SpecialProperty:
 
         def __init__(self, axis=0, doc=""):
             self.axis = axis

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -65,7 +65,7 @@ def test_MyClass(sphinx_app):
 
 
 def test_my_function(sphinx_app):
-    """Test that a timings page is created."""
+    """Test that function documentation is reasonable."""
     out_dir = sphinx_app.outdir
     function_html = op.join(out_dir, 'generated',
                             'numpydoc_test_module.my_function.html')

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -77,25 +77,20 @@ def test_my_function(sphinx_app):
     assert 'glossary.html#term-iterable' in html
 
 
-def test_reference(sphinx_app):
+@pytest.mark.parametrize(("html_file", "expected_length"), (
+    (["index.html"], 1),
+    (["generated", "numpydoc_test_module.my_function.html"], 1),
+    (["generated", "numpydoc_test_module.MyClass.html"], 1),
+))
+def test_reference(sphinx_app, html_file, expected_length):
     """Test for bad references"""
     out_dir = sphinx_app.outdir
-    html_files = [
-        ["index.html"],
-        ["generated", "numpydoc_test_module.my_function.html"],
-        ["generated", "numpydoc_test_module.MyClass.html"],
-    ]
 
-    expected_lengths = [1, 1, 1]
+    with open(op.join(out_dir, *html_file), 'r') as fid:
+        html = fid.read()
 
-    for html_file, expected_length in zip(html_files, expected_lengths):
-        html_file = op.join(out_dir, *html_file)
+    reference_list = re.findall(r'<a class="fn-backref" href="\#id\d+">(.*)<\/a>', html)
 
-        with open(html_file, 'r') as fid:
-            html = fid.read()
-
-        reference_list = re.findall(r'<a class="fn-backref" href="\#id\d+">(.*)<\/a>', html)
-
-        assert len(reference_list) == expected_length
-        for ref in reference_list:
-            assert '-' not in ref  # Bad reference if it contains "-" e.g. R1896e33633d5-1
+    assert len(reference_list) == expected_length
+    for ref in reference_list:
+        assert '-' not in ref  # Bad reference if it contains "-" e.g. R1896e33633d5-1

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -25,11 +25,12 @@ def sphinx_app(tmpdir_factory):
     conf_dir = temp_dir
     out_dir = op.join(temp_dir, '_build', 'html')
     toctrees_dir = op.join(temp_dir, '_build', 'toctrees')
-    # Avoid warnings about re-registration, see:
-    # https://github.com/sphinx-doc/sphinx/issues/5038
+    # Set behavior across different Sphinx versions
     kwargs = dict()
     if LooseVersion(sphinx.__version__) >= LooseVersion('1.8'):
         kwargs.update(warningiserror=True, keep_going=True)
+    # Avoid warnings about re-registration, see:
+    # https://github.com/sphinx-doc/sphinx/issues/5038
     with docutils_namespace():
         app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
                      buildername='html', **kwargs)

--- a/numpydoc/tests/test_xref.py
+++ b/numpydoc/tests/test_xref.py
@@ -1,4 +1,5 @@
 # -*- encoding:utf-8 -*-
+import pytest
 from numpydoc.xref import make_xref
 
 xref_aliases = {
@@ -114,12 +115,9 @@ dict[tuple(str, str), int]
 xref_ignore = {'or', 'in', 'of', 'default', 'optional'}
 
 
-def test_make_xref():
-    for s in data.strip().split('\n\n'):
-        param_type, expected_result = s.split('\n')
-        result = make_xref(
-            param_type,
-            xref_aliases,
-            xref_ignore
-        )
-        assert result == expected_result
+@pytest.mark.parametrize(
+    ('param_type', 'expected_result'),
+    [tuple(s.split('\n')) for s in data.strip().split('\n\n')]
+)
+def test_make_xref(param_type, expected_result):
+    assert make_xref(param_type, xref_aliases, xref_ignore) == expected_result

--- a/numpydoc/tests/tinybuild/numpydoc_test_module.py
+++ b/numpydoc/tests/tinybuild/numpydoc_test_module.py
@@ -18,7 +18,7 @@ References
 __all__ = ['MyClass', 'my_function']
 
 
-class MyClass(object):
+class MyClass:
     """A class.
 
     Reference [2]_


### PR DESCRIPTION
I recently read through the test suite as part of an ongoing effort to improve my understanding of numpydoc. While reading through the tests, I collated a list of suggestions/minor improvements. I've tried to make the commits very fine-grained so that individual suggestions that are not desired or cause too much churn can be ignored. Here's a brief summary of the changes:

**Fixes to docstrings/comments**
 - 86e0f2d: fixes the docstring of one of the tests that hadn't been changed from the project it was adopted from (sphinx-gallery)
 - 74067a6: A comment had become disconnected from the corresponding code block. Moved the original comment back to the corresponding code and added a new comment to distinguish the new code

**Parametrizations**
 - 02e05d1: Parametrized `test_reference` - arguably makes test more readable/extensible
 - 6603f24: Parametrized `test_xref` - the main benefit being now each xref is treated as its own test (rather than a single test that checks ~30 individual cases). In principle, this would make it easier to track down individual xref failures in the future.

**Py3K-related code style**
 - dd088b2: Removes explicitly inheriting from `object`

Please let me know if you think any of these changes are worth it. I'm happy to revert individual commits for things that aren't or that cause too much churn.