### PR TITLE
MAINT: remove unreachable codepath.

### DIFF
--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -52,10 +52,6 @@ class SphinxDocString(NumpyDocString):
 
     def _str_signature(self):
         return ['']
-        if self['Signature']:
-            return ['``%s``' % self['Signature']] + ['']
-        else:
-            return ['']
 
     def _str_summary(self):
         return self['Summary'] + ['']


### PR DESCRIPTION
I'm not sure what the wider context for this bit is (`git blame` didn't indicate that this was a mistake) but AFAICT this is unreachable code that is similar (but not identical) to the implementation in the base class `NumpyDocString`.