### PR TITLE
Cope with unexpected signature

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -215,7 +215,10 @@ def _clean_text_signature(sig):
     if sig is None:
         return None
     start_pattern = re.compile(r"^[^(]*\(")
-    start, end = start_pattern.search(sig).span()
+    try:
+        start, end = start_pattern.search(sig).span()
+    except TypeError:
+        return None
     start_sig = sig[start:end]
     sig = sig[end:-1]
     sig = re.sub(r'^\$(self|module|type)(,\s|$)','' , sig, count=1)


### PR DESCRIPTION
Fixes a regression in numpydoc v1.1.0 compared to v1.0.0 which did not have the ``_clean_text_signature`` function, manifested as:

``Handler <function mangle_signature at 0x7f8ae571b620> for event 'autodoc-process-signature' threw an exception``

I don't have a minimal test case, something strange in Biopython's ``Bio.Restriction`` triggered this - a module which creates a vast number of classes which we currently try to exclude from the Sphinx API docs via mocking the import. See https://github.com/biopython/biopython/issues/3024