### PR TITLE
BUG: Properly parse See Also when summary on first line.

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -284,6 +284,8 @@ class NumpyDocString(Mapping):
 
         """
 
+        content = dedent_lines(content)
+
         items = []
 
         def parse_item_name(text):

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -17,6 +17,7 @@ from numpydoc.docscrape import (
 )
 from numpydoc.docscrape_sphinx import (SphinxDocString, SphinxClassDoc,
                                        SphinxFunctionDoc, get_doc_object)
+import pytest
 from pytest import raises as assert_raises
 from pytest import warns as assert_warns
 
@@ -766,11 +767,10 @@ def test_warns():
     assert param.type == 'SomeWarning'
     assert param.desc == ['If needed']
 
-
-def test_see_also():
+@pytest.mark.parametrize('prefix', ['', '\n    '])
+def test_see_also(prefix):
     doc6 = NumpyDocString(
-    """
-    z(x,theta)
+    prefix + """z(x,theta)
 
     See Also
     --------


### PR DESCRIPTION
in a case like:

```
"""signature

See Also
--------
a,b,c,d

""""
```

Numpydoc would incorrectly assign `a, b, c, d` as a description with no
name, or type associated items.

Closes #281