### PR TITLE
document default values as part of the type spec

### DIFF
--- a/doc/format.rst
+++ b/doc/format.rst
@@ -197,7 +197,7 @@ The sections of a function's docstring are:
      Description of parameter `x` (the default is -1, which implies summation
      over all axes).
 
-   or as part of the type::
+   or as part of the type, instead of "optional"::
 
      copy : bool, default True
      dtype : data-type, default: int

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -197,12 +197,12 @@ The sections of a function's docstring are:
      Description of parameter `x` (the default is -1, which implies summation
      over all axes).
 
-   or as part of the type, instead of "optional"::
+   or as part of the type, instead of ``optional``. If the default value would not be
+   used as a value, ``optional`` is preferred. These are all equivalent::
 
      copy : bool, default True
-     dtype : data-type, default: int
-
-   where the colon is completely optional.
+     copy : bool, default=True
+     copy : bool, default: True
 
    When a parameter can only assume one of a fixed set of values,
    those values can be listed in braces, with the default appearing first::

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -197,6 +197,13 @@ The sections of a function's docstring are:
      Description of parameter `x` (the default is -1, which implies summation
      over all axes).
 
+   or as part of the type::
+
+     copy : bool, default True
+     dtype : data-type, default: int
+
+   where the colon is completely optional.
+
    When a parameter can only assume one of a fixed set of values,
    those values can be listed in braces, with the default appearing first::
 


### PR DESCRIPTION
Not sure if there is a better way to state that the colon is a matter of taste and has no effect on the generated documentation.

- [x] closes #284