### PR TITLE
MAINT: rm redundant listing of section titles.

### DIFF
--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -18,20 +18,7 @@ from .docscrape import NumpyDocString
 DIRECTIVES = ["versionadded", "versionchanged", "deprecated"]
 DIRECTIVE_PATTERN = re.compile(r"^\s*\.\. ({})(?!::)".format('|'.join(DIRECTIVES)),
                                re.I | re.M)
-ALLOWED_SECTIONS = [
-    "Parameters",
-    "Attributes",
-    "Methods",
-    "Returns",
-    "Yields",
-    "Other Parameters",
-    "Raises",
-    "Warns",
-    "See Also",
-    "Notes",
-    "References",
-    "Examples",
-]
+ALLOWED_SECTIONS = list(NumpyDocString.sections.keys())
 ERROR_MSGS = {
     "GL01": "Docstring text (summary) should start in the line immediately "
     "after the opening quotes (not in the same line, or leaving a "


### PR DESCRIPTION
The validation module maintained an independent listing of valid
section modules. This information is already included in the
class attribute of NumpyDocString. This change improves maintainability
by removing this redundancy so that, if there is ever a change to the
standard in the future, it does not need to be repeated in multiple
locations in the source code.