### PR TITLE
DOC: fix inaccuracy in validate docstring.

### DIFF
--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -425,14 +425,17 @@ def _check_desc(desc, code_no_desc, code_no_upper, code_no_period, **kwargs):
     return errs
 
 
-def validate(func_name):
+def validate(obj_name):
     """
     Validate the docstring.
 
     Parameters
     ----------
-    func_name : function
-        Function whose docstring will be evaluated (e.g. pandas.read_csv).
+    obj_name : str
+        The name of the object whose docstring will be evaluated, e.g.
+        'pandas.read_csv'. The string must include the full, unabbreviated
+        package/module names, i.e. 'pandas.read_csv', not 'pd.read_csv' or
+        'read_csv'.
 
     Returns
     -------

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -468,7 +468,7 @@ def validate(obj_name):
     they are validated, are not documented more than in the source code of this
     function.
     """
-    doc = Docstring(func_name)
+    doc = Docstring(obj_name)
 
     errs = []
     if not doc.raw_doc:


### PR DESCRIPTION
Fix inaccurate parameter description of the `validate` function. Also changed the parameter name to be more general and beefed up the parameter description.