### PR TITLE
MAINT: pytest ignore doc directory.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [tool:pytest]
 addopts =
     --showlocals --doctest-modules -ra --cov-report= --cov=numpydoc
-    --junit-xml=junit-results.xml --ignore=doc/conf.py
+    --junit-xml=junit-results.xml --ignore=doc/
 junit_family = xunit2
 filterwarnings =
     ignore:'U' mode is deprecated:DeprecationWarning


### PR DESCRIPTION
Update pytest config to ignore entire doc/ directory instead of only `doc/conf.py`. This prevents an import name collision with `doc/scipy-sphinx-theme/conf.py` during test collection when the user has inited the scipy-sphinx-theme submodule (and is calling pytest without the module name, i.e. `pytest` or `pytest .`).

Alternatively, `--ignore=doc/scipy-sphinx-theme/conf.py` could be added to `setup.cfg` to achieve the same effect without ignoring the entire doc directory.