### PR TITLE
MAINT: minor refactoring in docscrape

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -544,10 +544,6 @@ def dedent_lines(lines):
     return textwrap.dedent("\n".join(lines)).split("\n")
 
 
-def header(text, style='-'):
-    return text + '\n' + style*len(text) + '\n'
-
-
 class FunctionDoc(NumpyDocString):
     def __init__(self, func, role='func', doc=None, config={}):
         self._f = func

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -431,28 +431,22 @@ class NumpyDocString(Mapping):
         return [name, len(name)*symbol]
 
     def _str_indent(self, doc, indent=4):
-        out = []
-        for line in doc:
-            out += [' '*indent + line]
-        return out
+        return [' '*indent + line for line in doc]
 
     def _str_signature(self):
         if self['Signature']:
             return [self['Signature'].replace('*', r'\*')] + ['']
-        else:
-            return ['']
+        return ['']
 
     def _str_summary(self):
         if self['Summary']:
             return self['Summary'] + ['']
-        else:
-            return []
+        return []
 
     def _str_extended_summary(self):
         if self['Extended Summary']:
             return self['Extended Summary'] + ['']
-        else:
-            return []
+        return []
 
     def _str_param_list(self, name):
         out = []
@@ -525,8 +519,7 @@ class NumpyDocString(Mapping):
             out += ['   :%s: %s' % (section, ', '.join(references))]
         if output_index:
             return out
-        else:
-            return ''
+        return ''
 
     def __str__(self, func_role=''):
         out = []

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -539,14 +539,6 @@ class NumpyDocString(Mapping):
         return '\n'.join(out)
 
 
-def indent(str, indent=4):
-    indent_str = ' '*indent
-    if str is None:
-        return indent_str
-    lines = str.split('\n')
-    return '\n'.join(indent_str + l for l in lines)
-
-
 def dedent_lines(lines):
     """Deindent a list of lines maximally"""
     return textwrap.dedent("\n".join(lines)).split("\n")


### PR DESCRIPTION
A few removals from the docscrape module:
 * b9f94ff replaces a few `if: return, else: return` patterns and rewrites a method w/ list comprehension for improved readibility.
 * a4669d2 and b39d207 remove two functions from `docscape`, `indent` and `header` respectively. These functions are not used internally in `numpydoc` anywhere; however, they are not "private" (prefixed with `_`) so it is possible their removal could impact downstream projects. If this is a problem please LMK and I will revert.