### PR TITLE
ENH: Modify the markups for parameters (`x` to *x*)

### DIFF
--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -93,12 +93,7 @@ class SphinxDocString(NumpyDocString):
         return out
 
     def _escape_args_and_kwargs(self, name):
-        if name[:2] == '**':
-            return r'\*\*' + name[2:]
-        elif name[:1] == '*':
-            return r'\*' + name[1:]
-        else:
-            return name
+        return name.replace('*', '\*')
 
     def _process_param(self, param, desc, fake_autosummary):
         """Determine how to display a parameter
@@ -398,6 +393,16 @@ class SphinxDocString(NumpyDocString):
         ns = dict((k, '\n'.join(v)) for k, v in ns.items())
 
         rendered = self.template.render(**ns)
+
+        # Modify the markups for parameters (`x` to *x*)
+        for param_section in ['Parameters', 'Other Parameters', 'Attributes']:
+            for param in self[param_section]:
+                rendered = re.sub(
+                    r'([^`:])`' + self._escape_args_and_kwargs(param.name) + r'`',
+                    r'\1*' + param.name + r'*',
+                    rendered,
+                )
+
         return '\n'.join(self._str_indent(rendered.split('\n'), indent))
 
 


### PR DESCRIPTION
Related to https://github.com/numpy/numpy/pull/17714 .

Currently, `numpydoc` do nothing about the markup for single backticks (`` `x` ``). Sphinx seems to interpret `` `x` `` as a parameter name (`*x*`) when the python object `x` doesn't exists, and a reference (`` :obj:`x` ``) otherwise. This process works fine in most cases, but doesn't work if a python object which has the same name as the parameter name exists (see https://github.com/numpy/numpy/pull/17714#issuecomment-722417682 : collision between `` `size` `` parameter and `numpy.size`).  So I added a process to convert `` `x` `` to `` *x* `` for a parameter name `x`. 