### PR TITLE
Improve error messages for see also parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     - python: 3.7
     - python: 3.6
       env: SPHINX_SPEC="==2.1.0" SPHINXOPTS=""
-    - python: 3.5
+    - python: 3.6
       env: SPHINX_SPEC="==1.6.5" SPHINXOPTS=""
 
 before_install:

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -294,7 +294,7 @@ class NumpyDocString(Mapping):
             """Match ':role:`name`' or 'name'."""
             m = self._func_rgx.match(text)
             if not m:
-                raise ParseError("%s is not a item name" % text)
+                self._error_location(f"Error parsing See Also entry {line!r}")
             role = m.group('role')
             name = m.group('name') if role else m.group('name2')
             return name, role, m.end()
@@ -329,7 +329,7 @@ class NumpyDocString(Mapping):
                 rest = list(filter(None, [description]))
                 items.append((funcs, rest))
             else:
-                raise ParseError("%s is not a item name" % line)
+                self._error_location(f"Error parsing See Also entry {line!r}")
         return items
 
     def _parse_index(self, section, content):

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -418,8 +418,8 @@ class NumpyDocString(Mapping):
                 filename = inspect.getsourcefile(self._obj)
             except TypeError:
                 filename = None
-            msg = msg + (" in the docstring of %s in %s."
-                         % (self._obj, filename))
+            msg += f" in the docstring of {self._obj.__name__}"
+            msg += f" in {filename}." if filename else ""
         if error:
             raise ValueError(msg)
         else:

--- a/numpydoc/tests/test_main.py
+++ b/numpydoc/tests/test_main.py
@@ -87,7 +87,7 @@ def test_render_object_returns_correct_exit_status():
         'numpydoc.tests.test_main._capture_stdout')
     assert exit_status == 0
 
-    with pytest.raises(numpydoc.docscrape.ParseError):
+    with pytest.raises(ValueError):
         numpydoc.__main__.render_object(
             'numpydoc.tests.test_main._invalid_docstring')
 


### PR DESCRIPTION
I ran into some exceptions raised while parsing improperly-formatted `See Also` entries and found the error messages difficult to understand. Currently, numpydoc raises a custom `ParseError` exception that includes the entire docstring in the error message. Also, due to the way these errors from an extension are being handled by sphinx, the type of the exception is lost when reported. An example of one of these error messages is below:

```
Extension error:
Handler <function mangle_signature at 0x7f559b202670> for event 'autodoc-process-signature' threw an exception (exception: floyd_warshall() is not a item name in 'Compute shortest paths between all nodes.\n\nParameters\n----------\nG : NetworkX graph\n\ncutoff : integer, optional\n    Depth at which to stop the search. Only paths of length at most\n    `cutoff` are returned.\n\nReturns\n-------\nlengths : dictionary\n    Dictionary, keyed by source and target, of shortest paths.\n\nExamples\n--------\n>>> G = nx.path_graph(5)\n>>> path = dict(nx.all_pairs_shortest_path(G))\n>>> print(path[0][4])\n[0, 1, 2, 3, 4]\n\nSee Also\n--------\nfloyd_warshall()')
make: *** [Makefile:48: html] Error 2
```

This PR makes two changes to improve these error messages:
 1. Switch from the custom `ParseError` exception, which includes the entire docstring in the message, to the internal `_error_location` method, which includes only the object name and file location (if `_obj` exists).
 2. Minor updates to `_error_location` to improve readability:
    - Only include `_obj.__name__`, which eliminates the printing of addresses
    - Don't print "in None" when the originating file isn't found.

The above exception message now looks like:

```
Extension error:
Handler <function mangle_signature at 0x7f54a476b310> for event 'autodoc-process-signature' threw an exception (exception: Error parsing See Also entry 'floyd_warshall()' in the docstring of all_pairs_shortest_path in repos/networkx/networkx/algorithms/shortest_paths/unweighted.py.)
make: *** [Makefile:48: html] Error 2
```