### PR TITLE
BUG: fix an incomplete check in `Reader._error_location`

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -412,7 +412,7 @@ class NumpyDocString(Mapping):
                 self[section] = content
 
     def _error_location(self, msg, error=True):
-        if hasattr(self, '_obj'):
+        if hasattr(self, '_obj') and self._obj is not None:
             # we know where the docs came from:
             try:
                 filename = inspect.getsourcefile(self._obj)


### PR DESCRIPTION
It's unclear why `self._obj` can be None, but that's what I'm
seeing when trying numpydoc master to build SciPy master.

This fix gives the right traceback.