### PR TITLE
DOC: fix erroneous numpydoc_edit_link formatting

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -97,7 +97,7 @@ numpydoc_xref_ignore : set or ``"all"``
   ``numpydoc_xref_ignore="all"`` is more convenient than explicitly listing
   terms to ignore in a set.
 numpydoc_edit_link : bool
-  .. deprecated::
+  .. deprecated:: 0.7.0
   edit your HTML template instead
 
   Whether to insert an edit link after docstrings.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -77,25 +77,25 @@ numpydoc_xref_aliases : dict
   This option depends on the ``numpydoc_xref_param_type`` option
   being ``True``.
 numpydoc_xref_ignore : set or ``"all"``
-    How to handle terms not in ``numpydoc_xref_aliases`` when
-    ``numpydoc_xref_aliases=True``. The value can either be a ``set``
-    containing terms to ignore, or ``"all"``. In the former case, the set
-    contains words not to cross-reference. Most likely, these are common words
-    used in parameter type descriptions that may be confused for
-    classes of the same name. For example::
+  How to handle terms not in ``numpydoc_xref_aliases`` when
+  ``numpydoc_xref_aliases=True``. The value can either be a ``set``
+  containing terms to ignore, or ``"all"``. In the former case, the set
+  contains words not to cross-reference. Most likely, these are common words
+  used in parameter type descriptions that may be confused for
+  classes of the same name. For example::
 
-        numpydoc_xref_ignore = {'type', 'optional', 'default'}
+      numpydoc_xref_ignore = {'type', 'optional', 'default'}
 
-    The default is an empty set.
+  The default is an empty set.
 
-    If the ``numpydoc_xref_ignore="all"``, then all unrecognized terms are
-    ignored, i.e. terms not in ``numpydoc_xref_aliases`` are *not* wrapped in
-    ``:obj:`` roles.
-    This configuration parameter may be useful if you only want create
-    cross references for a small number of terms. In this case, including the
-    desired cross reference mappings in ``numpydoc_xref_aliases`` and setting
-    ``numpydoc_xref_ignore="all"`` is more convenient than explicitly listing
-    terms to ignore in a set.
+  If the ``numpydoc_xref_ignore="all"``, then all unrecognized terms are
+  ignored, i.e. terms not in ``numpydoc_xref_aliases`` are *not* wrapped in
+  ``:obj:`` roles.
+  This configuration parameter may be useful if you only want create
+  cross references for a small number of terms. In this case, including the
+  desired cross reference mappings in ``numpydoc_xref_aliases`` and setting
+  ``numpydoc_xref_ignore="all"`` is more convenient than explicitly listing
+  terms to ignore in a set.
 numpydoc_edit_link : bool
   .. deprecated::
   edit your HTML template instead

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -78,7 +78,7 @@ numpydoc_xref_aliases : dict
   being ``True``.
 numpydoc_xref_ignore : set or ``"all"``
     How to handle terms not in ``numpydoc_xref_aliases`` when
-    ``numpydoc_xref_aliases=True``. The value can either be a ``set`` 
+    ``numpydoc_xref_aliases=True``. The value can either be a ``set``
     containing terms to ignore, or ``"all"``. In the former case, the set
     contains words not to cross-reference. Most likely, these are common words
     used in parameter type descriptions that may be confused for
@@ -97,6 +97,7 @@ numpydoc_xref_ignore : set or ``"all"``
     ``numpydoc_xref_ignore="all"`` is more convenient than explicitly listing
     terms to ignore in a set.
 numpydoc_edit_link : bool
-  .. deprecated:: edit your HTML template instead
+  .. deprecated::
+  edit your HTML template instead
 
   Whether to insert an edit link after docstrings.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -98,6 +98,7 @@ numpydoc_xref_ignore : set or ``"all"``
   terms to ignore in a set.
 numpydoc_edit_link : bool
   .. deprecated:: 0.7.0
+
   edit your HTML template instead
 
   Whether to insert an edit link after docstrings.


### PR DESCRIPTION
This is mainly a fix for a missing linebreak in the documentation about `numpydoc_edit_link` which leads to a wrong rendering:

![image](https://user-images.githubusercontent.com/9084751/105380412-22518f00-5c0e-11eb-806c-6190df5761be.png)

see: https://numpydoc.readthedocs.io/en/latest/install.html#sphinx-config-options

I couldn't find which version `numpydoc_edit_link` was deprecated, so if someone knows, it'd be good to add the version after the directive.

Then I also corrected an indent for consistency, this should have no impact on the actual rendering