### PR TITLE
Be explicit about leading * when documenting *args, **kwargs.

### DIFF
--- a/doc/format.rst
+++ b/doc/format.rst
@@ -216,6 +216,18 @@ The sections of a function's docstring are:
      x1, x2 : array_like
          Input arrays, description of `x1`, `x2`.
 
+   When documenting variable length positional, or keyword arguments, leave the
+   leading star(s) in front of the name::
+
+     *args : tuple
+         Additional arguments should be passed as keyword arguments
+     **kwargs : dict, optional
+         Extra arguments to `metric`: refer to each metric documentation for a
+         list of all possible arguments.
+
+   ..
+      above example is from scipy.spatial.distance.pdist
+
 5. **Returns**
 
    Explanation of the returned values and their types. Similar to the


### PR DESCRIPTION
This seem to be what most docstring involving args/kwargs are doing
including the example.py; Though I've seen other project be less
consistant, so make the suggestion explicit instead of letting users
infer from the example.

Other convention I've seen are:
  - `*xi` , documented as `x1,x2, ..., xn : type`
  - just the name without the leading `*`/`**`.
  - prefixing `*` with `\\*`.