### PR TITLE
DOC: Switch docs to pydata-sphinx-theme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,8 @@ jobs:
             name: Get dependencies and install
             command: |
               pip install --user -q --upgrade pip setuptools
-              pip install --user -q --upgrade numpy matplotlib sphinx
+              pip install --user -q --upgrade numpy matplotlib sphinx pydata-sphinx-theme
               pip install --user -e .
-              git submodule init
-              git submodule update
         - save_cache:
             key: pip-cache
             paths:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [Ubuntu]
         python-version: [3.6, 3.7, 3.8, 3.9]
-        sphinx-version: ["sphinx==1.6.5", "sphinx==2.1", "sphinx>3.0"]
+        sphinx-version: ["sphinx==1.8.0", "sphinx==2.1", "sphinx>3.0"]
     steps:
     - uses: actions/checkout@v2
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,6 @@ jobs:
 
     - name: Setup for doc build
       run: |
-        # Get scipy-sphinx-theme
-        git submodule update --init
         sudo apt install texlive texlive-latex-extra latexmk dvipng
 
     - name: Build documentation

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "doc/scipy-sphinx-theme"]
-	path = doc/scipy-sphinx-theme
-	url = https://github.com/scipy/scipy-sphinx-theme

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -132,6 +132,9 @@ pygments_style = 'sphinx'
 # a list of builtin themes.
 
 html_theme = "pydata_sphinx_theme"
+html_theme_options = {
+    "github_url": "https://github.com/numpy/numpydoc"
+}
 
 html_title = "%s v%s Manual" % (project, version)
 html_last_updated_fmt = '%b %d, %Y'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -133,11 +133,14 @@ pygments_style = 'sphinx'
 
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
-    "github_url": "https://github.com/numpy/numpydoc"
+    "github_url": "https://github.com/numpy/numpydoc",
 }
 
 html_title = "%s v%s Manual" % (project, version)
 html_last_updated_fmt = '%b %d, %Y'
+html_sidebars = {
+    "**": ["sidebar-search-bs.html", "docs-toc.html"],
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -134,13 +134,15 @@ pygments_style = 'sphinx'
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "github_url": "https://github.com/numpy/numpydoc",
+    "show_prev_next": False,
+    "search_bar_position": "navbar",
+}
+html_sidebars = {
+    "**": [],
 }
 
 html_title = "%s v%s Manual" % (project, version)
 html_last_updated_fmt = '%b %d, %Y'
-html_sidebars = {
-    "**": ["sidebar-search-bs.html", "docs-toc.html"],
-}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -99,7 +99,7 @@ numpydoc_validation_checks = {"all", "GL01", "SA04", "RT03"}
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'scipy-sphinx-theme']
+exclude_patterns = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -131,32 +131,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-themedir = os.path.join(os.path.dirname(__file__), 'scipy-sphinx-theme', '_theme')
-if not os.path.isdir(themedir):
-    raise RuntimeError("Get the scipy-sphinx-theme first, "
-                       "via git submodule init && git submodule update")
-
-html_theme = 'scipy'
-html_theme_path = [themedir]
-
-if 'scipyorg' in tags:  # noqa: F821
-    # Build for the scipy.org website
-    html_theme_options = {
-        "edit_link": True,
-        "sidebar": "right",
-        "scipy_org_logo": True,
-        "rootlinks": [("https://scipy.org/", "Scipy.org"),
-                      ("https://docs.scipy.org/", "Docs")]
-    }
-else:
-    # Default build
-    html_theme_options = {
-        "edit_link": False,
-        "sidebar": "left",
-        "scipy_org_logo": False,
-        "rootlinks": []
-    }
-    html_sidebars = {}
+html_theme = "pydata_sphinx_theme"
 
 html_title = "%s v%s Manual" % (project, version)
 html_last_updated_fmt = '%b %d, %Y'

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -1,8 +1,3 @@
-.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
-   pydata-sphinx-theme.
-
-:notoc:
-
 .. _example:
 
 =======

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -1,3 +1,7 @@
+.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
+   pydata-sphinx-theme.
+
+:notoc:
 
 .. _example:
 

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -1,3 +1,7 @@
+.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
+   pydata-sphinx-theme.
+
+:notoc:
 
 .. _format:
 

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -1,15 +1,8 @@
-.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
-   pydata-sphinx-theme.
-
-:notoc:
-
 .. _format:
 
-========================
-numpydoc docstring guide
-========================
-
-.. Contents::
+===========
+Style guide
+===========
 
 This document describes the syntax and best practices for docstrings used with
 the numpydoc extension for Sphinx_.
@@ -356,7 +349,7 @@ The sections of a function's docstring are:
     code, possibly including a discussion of the algorithm. This
     section may include mathematical equations, written in
     `LaTeX <https://www.latex-project.org/>`_ format::
-    
+
       Notes
       -----
       The FFT is a fast implementation of the discrete Fourier transform:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,8 +1,3 @@
-.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
-   pydata-sphinx-theme.
-
-:notoc:
-
 =====================================
 numpydoc -- Numpy's Sphinx extensions
 =====================================
@@ -20,14 +15,11 @@ Sphinx, and adds the code description directives ``np:function``,
 - PyPI: https://pypi.python.org/pypi/numpydoc/
 
 
-Documentation
-=============
-
 .. toctree::
-    :maxdepth: 2
+    :hidden:
 
     install
-    release_notes
     format
-    example
     validation
+    release_notes
+    example

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,3 +1,8 @@
+.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
+   pydata-sphinx-theme.
+
+:notoc:
+
 =====================================
 numpydoc -- Numpy's Sphinx extensions
 =====================================

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,3 +1,7 @@
+.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
+   pydata-sphinx-theme.
+
+:notoc:
 
 ============
 Installation

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,23 +1,21 @@
-.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
-   pydata-sphinx-theme.
+===============
+Getting started
+===============
 
-:notoc:
-
-============
 Installation
 ============
 
-This extension requires Python 3.5+, sphinx 1.6.5+ and is available from:
+This extension requires Python 3.5+, sphinx 1.8+ and is available from:
 
 * `numpydoc on PyPI <http://pypi.python.org/pypi/numpydoc>`_
 * `numpydoc on GitHub <https://github.com/numpy/numpydoc/>`_
 
-'numpydoc' should be added to the ``extensions`` option in your Sphinx
-``conf.py``. (Note that `sphinx.ext.autosummary` will automatically be loaded
-as well.)
+`'numpydoc'` should be added to the ``extensions`` option in your Sphinx
+``conf.py``. ``'sphinx.ext.autosummary'`` will automatically be loaded
+as well.
 
-Sphinx config options
-=====================
+Configuration
+=============
 
 The following options can be set in your Sphinx ``conf.py``:
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,8 +1,3 @@
-.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
-   pydata-sphinx-theme.
-
-:notoc:
-
 Release notes
 =============
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,3 +1,8 @@
+.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
+   pydata-sphinx-theme.
+
+:notoc:
+
 Release notes
 =============
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 matplotlib
+pydata-sphinx-theme

--- a/doc/validation.rst
+++ b/doc/validation.rst
@@ -1,11 +1,9 @@
-.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
-   pydata-sphinx-theme.
+==========
+Validation
+==========
 
-:notoc:
-
-==============================
-Validating NumpyDoc docstrings
-==============================
+Docstring Validation using Python
+---------------------------------
 
 To see the Restructured Text generated for an object, the ``numpydoc`` module
 can be called. For example, to do it for ``numpy.ndarray``, use:

--- a/doc/validation.rst
+++ b/doc/validation.rst
@@ -1,3 +1,8 @@
+.. NOTE: The :notoc: metadata is used to suppress the right-sidebar in the
+   pydata-sphinx-theme.
+
+:notoc:
+
 ==============================
 Validating NumpyDoc docstrings
 ==============================


### PR DESCRIPTION
NumPy recently switched to the [pydata-sphinx-theme](https://pydata-sphinx-theme.readthedocs.io/en/latest/index.html) for its documentation. The new theme is now deployed for the [stable docs](https://numpy.org/doc/stable/) as of v1.20. This PR switches the themes so numpydoc's documentation theme is consistent with numpy's.