### PR TITLE
MAINT: changes related to renaming default branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: numpydoc tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-.. image:: https://travis-ci.org/numpy/numpydoc.png?branch=master
-   :target: https://travis-ci.org/numpy/numpydoc/
-
 .. |docs| image:: https://readthedocs.org/projects/numpydoc/badge/?version=latest
    :alt: Documentation Status
    :scale: 100%

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,6 +63,9 @@ source_suffix = '.rst'
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
+# The root toctree document
+master_doc = 'index'  # NOTE: will be changed to `root_doc` in sphinx 4
+
 # General information about the project.
 project = u'numpydoc'
 copyright = u'2019, numpydoc maintainers'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,9 +63,6 @@ source_suffix = '.rst'
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
-
 # General information about the project.
 project = u'numpydoc'
 copyright = u'2019, numpydoc maintainers'

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -8,7 +8,7 @@ Source
 ======
 
 .. literalinclude:: example.py
-   :caption: `example.py <http://github.com/numpy/numpydoc/blob/master/doc/example.py>`_
+   :caption: `example.py <http://github.com/numpy/numpydoc/blob/main/doc/example.py>`_
    :language: python
 
 Rendered

--- a/numpydoc/tests/tinybuild/conf.py
+++ b/numpydoc/tests/tinybuild/conf.py
@@ -13,7 +13,6 @@ project = 'numpydoc_test_module'
 autosummary_generate = True
 autodoc_default_options = {'inherited-members': None}
 source_suffix = '.rst'
-master_doc = 'index'
 exclude_patterns = ['_build']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),

--- a/numpydoc/tests/tinybuild/conf.py
+++ b/numpydoc/tests/tinybuild/conf.py
@@ -13,6 +13,7 @@ project = 'numpydoc_test_module'
 autosummary_generate = True
 autodoc_default_options = {'inherited-members': None}
 source_suffix = '.rst'
+master_doc = 'index'  # NOTE: will be changed to `root_doc` in sphinx 4
 exclude_patterns = ['_build']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),


### PR DESCRIPTION
Update configuration, links, and docs to reflect new default branch name.

Not to be merged until default branch name is switched; marking as draft until then.