### PR TITLE
MAINT: use super() as described by PEP 3135

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -585,7 +585,7 @@ class FunctionDoc(NumpyDocString):
             out += '.. %s:: %s\n    \n\n' % (roles.get(self._role, ''),
                                              func_name)
 
-        out += super(FunctionDoc, self).__str__(func_role=self._role)
+        out += super().__str__(func_role=self._role)
         return out
 
 

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -295,7 +295,7 @@ class SphinxDocString(NumpyDocString):
     def _str_see_also(self, func_role):
         out = []
         if self['See Also']:
-            see_also = super(SphinxDocString, self)._str_see_also(func_role)
+            see_also = super()._str_see_also(func_role)
             out = ['.. seealso::', '']
             out += self._str_indent(see_also[2:])
         return out

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -344,7 +344,7 @@ class ManglingDomainBase(object):
     directive_mangling_map = {}
 
     def __init__(self, *a, **kw):
-        super(ManglingDomainBase, self).__init__(*a, **kw)
+        super().__init__(*a, **kw)
         self.wrap_mangling_directives()
 
     def wrap_mangling_directives(self):


### PR DESCRIPTION
This PR refactors `super()` to be simpler, as described by [PEP 3135](https://www.python.org/dev/peps/pep-3135/).

xref https://github.com/numpy/numpy/pull/18648 for more details and background.