### PR TITLE
MAINT: Update Circle and conf.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,17 @@ jobs:
         - run:
             name: make html
             command: |
-              cd doc
-              make html
+              make -C doc html
         - store_artifacts:
             path: doc/_build/html/
             destination: html
+        - run:
+            name: make tinybuild
+            command: |
+              make -C numpydoc/tests/tinybuild html
+        - store_artifacts:
+            path: numpydoc/tests/tinybuild/_build/html/
+            destination: tinybuild
 
 workflows:
   version: 2

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -135,7 +135,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "github_url": "https://github.com/numpy/numpydoc",
     "show_prev_next": False,
-    "search_bar_position": "navbar",
+    "navbar_end": ["search-field.html"],
 }
 html_sidebars = {
     "**": [],

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -135,7 +135,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "github_url": "https://github.com/numpy/numpydoc",
     "show_prev_next": False,
-    "navbar_end": ["search-field.html"],
+    "navbar_end": ["search-field.html", "navbar-icon-links.html"],
 }
 html_sidebars = {
     "**": [],


### PR DESCRIPTION
1. Fix bug with latest `main` CircleCI build where we used a deprecated way of putting the search in the navbar:

https://app.circleci.com/pipelines/github/numpy/numpydoc/287/workflows/e91a2751-3810-4e37-9ccb-f8f4e419ceb1/jobs/283

2. Add `tinybuild` to the CircleCI build. I wanted to look at the output so that I could see if the `*args, **kwargs` that [show up in the API docs there](https://github.com/numpy/numpydoc/blob/main/numpydoc/tests/tinybuild/numpydoc_test_module.py#L28-L31) render properly so that we can merge #310.

Closes #318