### PR TITLE
MAINT: Python3 classes do not need to inherit from object

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -21,7 +21,7 @@ def strip_blank_lines(l):
     return l
 
 
-class Reader(object):
+class Reader:
     """A line-based string reader.
 
     """

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -340,7 +340,7 @@ from sphinx.domains.c import CDomain
 from sphinx.domains.python import PythonDomain
 
 
-class ManglingDomainBase(object):
+class ManglingDomainBase:
     directive_mangling_map = {}
 
     def __init__(self, *a, **kw):


### PR DESCRIPTION
See https://github.com/numpy/numpy/pull/19035