### PR TITLE
improve section detection

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -196,15 +196,15 @@ class NumpyDocString(Mapping):
 
         return doc[i:len(doc)-j]
 
-    def _read_to_next_section(self):
-        section = self._doc.read_to_next_empty_line()
+    def _read_to_next_section(self, doc=None):
+        if doc is None:
+            doc = self._doc
 
-        while not self._is_at_section() and not self._doc.eof():
-            if not self._doc.peek(-1).strip():  # previous line was empty
-                section += ['']
-
-            section += self._doc.read_to_next_empty_line()
-
+        section = []
+        # make sure we actually read to the next section
+        if self._is_at_section(doc=doc):
+            section.append(doc.read())
+        section += doc.read_to_condition(lambda l: self._is_at_section(doc=doc))
         return section
 
     def _read_sections(self):

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -357,22 +357,25 @@ class NumpyDocString(Mapping):
         if self._is_at_section():
             return
 
+        entire_summary = Reader(self._read_to_next_section())
+
         # If several signatures present, take the last one
         while True:
-            summary = self._doc.read_to_next_empty_line()
+            summary = entire_summary.read_to_next_empty_line()
             summary_str = " ".join([s.strip() for s in summary]).strip()
             compiled = re.compile(r'^([\w., ]+=)?\s*[\w\.]+\(.*\)$')
             if compiled.match(summary_str):
                 self['Signature'] = summary_str
-                if not self._is_at_section():
+                if not self._is_at_section(doc=entire_summary):
                     continue
             break
 
         if summary is not None:
             self['Summary'] = summary
 
-        if not self._is_at_section():
-            self['Extended Summary'] = self._read_to_next_section()
+        if not self._is_at_section(doc=entire_summary):
+            entire_summary.seek_next_non_empty_line()
+            self['Extended Summary'] = self._read_to_next_section(doc=entire_summary)
 
     def _parse(self):
         self._doc.reset()

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -164,20 +164,21 @@ class NumpyDocString(Mapping):
     def __len__(self):
         return len(self._parsed_data)
 
-    def _is_at_section(self):
-        self._doc.seek_next_non_empty_line()
+    def _is_at_section(self, doc=None):
+        if doc is None:
+            doc = self._doc
 
-        if self._doc.eof():
+        if doc.eof():
             return False
 
-        l1 = self._doc.peek().strip()  # e.g. Parameters
+        l1 = doc.peek().strip()  # e.g. Parameters
 
         if l1.startswith('.. index::'):
             return True
 
-        l2 = self._doc.peek(1).strip()  # ---------- or ==========
+        l2 = doc.peek(1).strip()  # ---------- or ==========
         if len(l2) >= 3 and (set(l2) in ({'-'}, {'='}) ) and len(l2) != len(l1):
-            snip = '\n'.join(self._doc._str[:2])+'...'
+            snip = '\n'.join(doc._str[:2])+'...'
             self._error_location("potentially wrong underline length... \n%s \n%s in \n%s"\
                     % (l1, l2, snip), error=False)
         return l2.startswith('-'*len(l1)) or l2.startswith('='*len(l1))

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -934,6 +934,18 @@ def test_no_summary():
     ----------"""))
 
 
+def test_missing_blank_line_after_summary():
+    doc = NumpyDocString("""
+    Parameters without separating blank line:
+    Parameters
+    ----------
+    data
+        Some parameter.
+    """)
+    assert len(doc["Parameters"]) == 1
+    assert doc["Parameters"][0].name == "data"
+
+
 def test_unicode():
     doc = SphinxDocString("""
     öäöäöäöäöåååå

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -946,6 +946,22 @@ def test_missing_blank_line_after_summary():
     assert doc["Parameters"][0].name == "data"
 
 
+def test_missing_blank_line_between_sections():
+    doc = NumpyDocString("""
+    Parameters
+    ----------
+    data
+        Some parameter.
+    Returns
+    -------
+    int
+    """)
+    assert len(doc["Parameters"]) == 1
+    assert doc["Parameters"][0].name == "data"
+
+    assert len(doc["Returns"]) == 1
+
+
 def test_unicode():
     doc = SphinxDocString("""
     öäöäöäöäöåååå


### PR DESCRIPTION
Potentially fixes #316.

This tries to allow parsing sections which are not separated by blank lines (there should probably be a warning in that case, I'll add that once the general idea has been approved). In order to get this to work used a few tricks (e.g. add a optional `doc` parameter to `_is_at_section` to allow calling it on a different reader) so this might need some refactoring before being truly ready.

cc @Carreau, my main motivation was trying to get `velin` to auto-fix this