### PR TITLE
Correctly validate parameters under the "Other Parameters" section

### DIFF
--- a/doc/example.py
+++ b/doc/example.py
@@ -35,7 +35,7 @@ import matplotlib.pyplot as plt
 # numpy module itself, unabbreviated.
 
 
-def foo(var1, var2, *args, long_var_name='hi', **kwargs):
+def foo(var1, var2, *args, long_var_name='hi', only_seldom_used_keyword=0, **kwargs):
     r"""Summarize the function in one line.
 
     Several sentences providing an extended description. Refer to
@@ -70,10 +70,9 @@ def foo(var1, var2, *args, long_var_name='hi', **kwargs):
 
     Other Parameters
     ----------------
-    only_seldom_used_keywords : type
-        Explanation.
-    common_parameters_listed_above : type
-        Explanation.
+    only_seldom_used_keyword : int, optional
+        Infrequently used parameters can be described under this optional
+        section to prevent cluttering the Parameters section.
 
     Raises
     ------

--- a/doc/example.py
+++ b/doc/example.py
@@ -55,8 +55,6 @@ def foo(var1, var2, *args, long_var_name='hi', only_seldom_used_keyword=0, **kwa
         Other arguments.
     long_var_name : {'hi', 'ho'}, optional
         Choices in brackets, default first when optional.
-    **kwargs : dict
-        Keyword arguments.
 
     Returns
     -------
@@ -73,6 +71,11 @@ def foo(var1, var2, *args, long_var_name='hi', only_seldom_used_keyword=0, **kwa
     only_seldom_used_keyword : int, optional
         Infrequently used parameters can be described under this optional
         section to prevent cluttering the Parameters section.
+    **kwargs : dict
+        Other infrequently used keyword arguments. Note that all keyword
+        arguments appearing after the first parameter specified under the
+        Other Parameters section, should also be described under this
+        section.
 
     Raises
     ------

--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -410,6 +410,33 @@ class GoodDocStrings:
         """
         pass
 
+    def other_parameters(self, param1, param2):
+        """
+        Ensure "Other Parameters" are recognized.
+
+        The second parameter is used infrequently, so it is put in the
+        "Other Parameters" section.
+
+        Parameters
+        ----------
+        param1 : bool
+            Description of commonly used parameter.
+
+        Other Parameters
+        ----------------
+        param2 : str
+            Description of infrequently used parameter.
+
+        See Also
+        --------
+        related : Something related.
+
+        Examples
+        --------
+        >>> result = 1 + 1
+        """
+        pass
+
 
 class BadGenericDocStrings:
     """Everything here has a bad docstring
@@ -1039,6 +1066,7 @@ class TestValidator:
             "no_returns",
             "empty_returns",
             "multiple_variables_on_one_line",
+            "other_parameters",
         ],
     )
     def test_good_functions(self, capsys, func):

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -326,25 +326,15 @@ class Validator:
         extra = set(all_params) - set(signature_params)
         if extra:
             errs.append(error("PR02", unknown_params=str(extra)))
-        order_match = True
-        params, other_params = tuple(self.doc_parameters.keys()), tuple(self.doc_other_parameters.keys())
-        i_p, i_o = 0, 0
-        for param in signature_params:
-            if i_p < len(params) and param == params[i_p]:
-                i_p += 1
-            elif i_o < len(other_params) and param == other_params[i_o]:
-                i_o += 1
-            else:
-                order_match = False
-                break
         if (
             not missing
             and not extra
-            and not order_match
+            and signature_params != all_params
+            and not (not signature_params and not all_params)
         ):
             errs.append(
                 error(
-                    "PR03", actual_params=signature_params, documented_params="{}, {}".format(params, other_params)
+                    "PR03", actual_params=signature_params, documented_params=all_params
                 )
             )
 

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -9,6 +9,7 @@ import ast
 import collections
 import importlib
 import inspect
+import itertools
 import pydoc
 import re
 import textwrap
@@ -263,7 +264,7 @@ class Validator:
     @property
     def doc_parameters(self):
         parameters = collections.OrderedDict()
-        for names, type_, desc in self.doc["Parameters"]:
+        for names, type_, desc in itertools.chain(self.doc["Parameters"], self.doc["Other Parameters"]):
             for name in names.split(", "):
                 parameters[name] = (type_, desc)
         return parameters


### PR DESCRIPTION
The "PR01" error is falsely raised when validating doc strings with parameter definitions under the "Other Parameters" section (e.g. for infrequently used parameters). This PR makes sure such parameters are correctly recognized by the validation script (and an extra test is added that previously failed but is now properly supported).