### PR TITLE
Escape newline in docstring.

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -30,7 +30,7 @@ class Reader:
         Parameters
         ----------
         data : str
-           String with lines separated by '\n'.
+           String with lines separated by '\\n'.
 
         """
         if isinstance(data, list):


### PR DESCRIPTION
Otherwise  `'.` is seen as the second parameter.