### PR TITLE
Fix validation bug when parameter type is set of options.

### DIFF
--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -458,6 +458,28 @@ class GoodDocStrings:
         """
         pass
 
+    def valid_options_in_parameter_description_sets(self, bar):
+        """
+        Ensure a PR06 error is not raised when type is member of a set.
+
+        Literal keywords like 'integer' are valid when specified in a set of
+        valid options for a keyword parameter.
+
+        Parameters
+        ----------
+        bar : {'integer', 'boolean'}
+            The literal values of 'integer' and 'boolean' are part of an
+            options set and thus should not be subject to PR06 warnings.
+
+        See Also
+        --------
+        related : Something related.
+
+        Examples
+        --------
+        >>> result = 1 + 1
+        """
+
 
 class BadGenericDocStrings:
     """Everything here has a bad docstring
@@ -1089,6 +1111,7 @@ class TestValidator:
             "multiple_variables_on_one_line",
             "other_parameters",
             "warnings",
+            "valid_options_in_parameter_description_sets",
         ],
     )
     def test_good_functions(self, capsys, func):

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -564,6 +564,10 @@ def validate(obj_name):
             else:
                 if doc.parameter_type(param)[-1] == ".":
                     errs.append(error("PR05", param_name=param))
+                # skip common_type_error checks when the param type is a set of
+                # options
+                if "{" in doc.parameter_type(param):
+                    continue
                 common_type_errors = [
                     ("integer", "int"),
                     ("boolean", "bool"),


### PR DESCRIPTION
Fixes #341 

The docstring validation checks the parameter type and warns when certain keywords are used instead of the preferred abbreviation (e.g. `integer` instead of `int`). However, this validation check results in false positives if one of these special keywords is specified as a member of a set of valid options, see e.g. the example in #341.

This PR fixes the false positive by skipping the keyword validation when the parameter description is a set of options.