### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         sphinx-version: ["sphinx==1.8.0", "sphinx==2.1", "sphinx>3.0"]
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ docstrings formatted according to the NumPy documentation format.
 The extension also adds the code description directives
 ``np:function``, ``np-c:function``, etc.
 
-numpydoc requires Python 3.5+ and sphinx 1.6.5+.
+numpydoc requires Python 3.7+ and sphinx 1.6.5+.
 
 For usage information, please refer to the `documentation
 <https://numpydoc.readthedocs.io/>`_.

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ from distutils.core import setup
 
 from numpydoc import __version__ as version
 
-if sys.version_info < (3, 5):
-    raise RuntimeError("Python version >= 3.5 required.")
+if sys.version_info < (3, 7):
+    raise RuntimeError("Python version >= 3.7 required.")
 
 
 def read(fname):
@@ -35,11 +35,10 @@ setup(
                  "Topic :: Documentation",
                  "Programming Language :: Python",
                  "Programming Language :: Python :: 3",
-                 "Programming Language :: Python :: 3.5",
-                 "Programming Language :: Python :: 3.6",
                  "Programming Language :: Python :: 3.7",
                  "Programming Language :: Python :: 3.8",
                  "Programming Language :: Python :: 3.9",
+                 "Programming Language :: Python :: 3.10",
                  ],
     keywords="sphinx numpy",
     author="Pauli Virtanen and others",
@@ -47,7 +46,7 @@ setup(
     url="https://numpydoc.readthedocs.io",
     license="BSD",
     install_requires=["sphinx >= 1.6.5", 'Jinja2>=2.3'],
-    python_requires=">=3.5",
+    python_requires=">=3.7",
     extras_require={
         "testing": [
             req for req in read('test_requirements.txt').split('\n')


### PR DESCRIPTION
Drop support for 3.5 and 3.6
Add support for 3.10

3.6 EOL   23 Dec 2021
3.5 EOL   13 Sep 2020