### PR TITLE
Update deps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ docstrings formatted according to the NumPy documentation format.
 The extension also adds the code description directives
 ``np:function``, ``np-c:function``, etc.
 
-numpydoc requires Python 3.7+ and sphinx 1.6.5+.
+numpydoc requires Python 3.7+ and sphinx 1.8+.
 
 For usage information, please refer to the `documentation
 <https://numpydoc.readthedocs.io/>`_.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,7 +5,7 @@ Getting started
 Installation
 ============
 
-This extension requires Python 3.5+, sphinx 1.8+ and is available from:
+This extension requires Python 3.7+, sphinx 1.8+ and is available from:
 
 * `numpydoc on PyPI <http://pypi.python.org/pypi/numpydoc>`_
 * `numpydoc on GitHub <https://github.com/numpy/numpydoc/>`_

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     author_email="pav@iki.fi",
     url="https://numpydoc.readthedocs.io",
     license="BSD",
-    install_requires=["sphinx >= 1.6.5", 'Jinja2>=2.3'],
+    install_requires=["sphinx >= 1.8", 'Jinja2>=2.10'],
     python_requires=">=3.7",
     extras_require={
         "testing": [


### PR DESCRIPTION
sphinx is tested for 1.8+ and some documentation said we support 1.8+
and some said 1.6.5+.  Now it says 1.8+ everywhere.

I also said we need Jinja2 >= 2.10, which was released in 2017.  We
don't test old versions and I am not sure they even work on the versions
of Python we support (3.7 was released in 2018).