### PR TITLE
Require sphinx >= 1.8

### DIFF
--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -337,10 +337,7 @@ class SphinxDocString(NumpyDocString):
             out += ['']
             # Latex collects all references to a separate bibliography,
             # so we need to insert links to it
-            if sphinx.__version__ >= "0.6":
-                out += ['.. only:: latex', '']
-            else:
-                out += ['.. latexonly::', '']
+            out += ['.. only:: latex', '']
             items = []
             for line in self['References']:
                 m = re.match(r'.. \[([a-z0-9._-]+)\]', line, re.I)

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -30,8 +30,8 @@ from sphinx.addnodes import pending_xref, desc_content
 from sphinx.util import logging
 from sphinx.errors import ExtensionError
 
-if sphinx.__version__ < '1.6.5':
-    raise RuntimeError("Sphinx 1.6.5 or newer is required")
+if sphinx.__version__ < '1.8':
+    raise RuntimeError("Sphinx 1.8 or newer is required")
 
 from .docscrape_sphinx import get_doc_object
 from .validate import validate, ERROR_MSGS

--- a/numpydoc/tests/test_full.py
+++ b/numpydoc/tests/test_full.py
@@ -1,4 +1,3 @@
-from distutils.version import LooseVersion
 import os.path as op
 import re
 import shutil
@@ -25,10 +24,7 @@ def sphinx_app(tmpdir_factory):
     conf_dir = temp_dir
     out_dir = op.join(temp_dir, '_build', 'html')
     toctrees_dir = op.join(temp_dir, '_build', 'toctrees')
-    # Set behavior across different Sphinx versions
-    kwargs = dict()
-    if LooseVersion(sphinx.__version__) >= LooseVersion('1.8'):
-        kwargs.update(warningiserror=True, keep_going=True)
+    kwargs = {'warningiserror': True, 'keep_going': True}
     # Avoid warnings about re-registration, see:
     # https://github.com/sphinx-doc/sphinx/issues/5038
     with docutils_namespace():


### PR DESCRIPTION
We already require sphinx>=1.8, but I missed these earlier.  Close #324.