### PR TITLE
Fix AttributeError in underline length check

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -426,7 +426,12 @@ class NumpyDocString(Mapping):
                 filename = inspect.getsourcefile(self._obj)
             except TypeError:
                 filename = None
-            msg += f" in the docstring of {self._obj.__name__}"
+            # Make UserWarning more descriptive via object introspection.
+            # Skip if introspection fails
+            try:
+                msg += f" in the docstring of {self._obj.__name__}"
+            except AttributeError:
+                pass
             msg += f" in {filename}." if filename else ""
         if error:
             raise ValueError(msg)

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -428,10 +428,11 @@ class NumpyDocString(Mapping):
                 filename = None
             # Make UserWarning more descriptive via object introspection.
             # Skip if introspection fails
-            try:
-                msg += f" in the docstring of {self._obj.__name__}"
-            except AttributeError:
-                pass
+            name = getattr(self._obj, '__name__', None)
+            if name is None:
+                name = getattr(getattr(self._obj, '__class__', None), '__name__', None)
+            if name is not None:
+                msg += f" in the docstring of {name}"
             msg += f" in {filename}." if filename else ""
         if error:
             raise ValueError(msg)

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1543,7 +1543,7 @@ def test__error_location_no_name_attr():
     # Create an NumpyDocString instance to call the _error_location method
     nds = get_doc_object(foo)
 
-    msg = "Potentially wrong underline length"
+    msg = "Potentially wrong underline length.*Foo.*"
     with pytest.raises(ValueError, match=msg):
         nds._error_location(msg=msg)
 

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1522,6 +1522,32 @@ def test_xref():
     line_by_line_compare(str(doc), xref_doc_txt_expected)
 
 
+def test__error_location_no_name_attr():
+    """
+    Ensure that NumpyDocString._error_location doesn't fail when self._obj
+    does not have a __name__ attr.
+
+    See gh-362
+    """
+    from collections.abc import Callable
+
+    # Create a Callable that doesn't have a __name__ attribute
+    class Foo():
+        def __call__(self):
+            pass
+
+
+    foo = Foo()  # foo is a Callable, but no a function instance
+    assert isinstance(foo, Callable)
+
+    # Create an NumpyDocString instance to call the _error_location method
+    nds = get_doc_object(foo)
+
+    msg = "Potentially wrong underline length"
+    with pytest.raises(ValueError, match=msg):
+        nds._error_location(msg=msg)
+
+
 if __name__ == "__main__":
     import pytest
     pytest.main()


### PR DESCRIPTION
Fixes gh-362.

The `NumpyDocString` class raises a `UserWarning` during docstring parsing when the underline length doesn't match the header length. In an attempt to make this `UserWarning` more informative, some introspection is performed to try to get the name and location of the object. This introspection relied on the assumption that the object would have a `__name__` attribute, which is not always the case, e.g. when `_obj` is an instance of a user-defined `Callable`.

This PR fixes the issue by only reporting the improved UserWarning message when the introspection is successful. 