### PR TITLE
DOC: include keyword-only parameters in standard

### DIFF
--- a/doc/format.rst
+++ b/doc/format.rst
@@ -211,6 +211,10 @@ used as a value, ``optional`` is preferred. These are all equivalent::
   copy : bool, default=True
   copy : bool, default: True
 
+For keyword-only arguments, use ``keyword-only``::
+
+  x : int, keyword-only
+
 When a parameter can only assume one of a fixed set of values,
 those values can be listed in braces, with the default appearing first::
 


### PR DESCRIPTION
This PR adds keyword-only parameters to the numpydoc style guide, which were added in [PEP 3102](https://www.python.org/dev/peps/pep-3102/).  This change would specify that `keyword-only` gets added next to the type information, like with `optional`.  This was suggested in #330.  Here are two examples:

```Python
def f(*, x, y=None):
    """
    Parameters
    ----------
    x : int, keyword-only
        ...
    y : int, optional, keyword_only
        ...
    """
    ...
```

Here are some alternatives that I considered:
 - *Specify that a parameter is keyword-only in the description of the parameter.*  Some examples.
   ```Python
   def f(*, x=None, y=None):
       """
       Parameters
       ----------
       x : int, optional
           Some number.  Keyword-only.
       y : int, optional
           Or it could be in parentheses (keyword-only).  
       """
   ```
   I didn't choose this approach since the `keyword-only` might be missed by someone who is quickly scanning through the parameters, and because the information about if something is keyword-only is closely related to the information about if a parameter is optional.
 - *Include a separate section for keyword-only parameters.*  I didn't do this because if a parameter is keyword-only and required, someone might miss it if it is in a different section.
 - *Do not include keyword-only parameters in the standard.* I didn't choose this approach because right now there are different practices for specifying keyword-only parameters.  If someone is expecting `keyword-only` to show up next to the type, then they would be more likely to miss it if it is in the parameter description.  Also, if someone wanted to create an automated tool to automatically link to a definition of `keyword-only`, having a standard to follow would make it easier to implement.

Closes #330.  I'm open to alternatives and edits, in case anyone has suggestions.  Many thanks!