### PR TITLE
Update tests + coverage config to rm warnings.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 [run]
 branch = True
 source = numpydoc
-include = */numpydoc/*
 omit =
     */setup.py
     numpydoc/tests/*

--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 import numpydoc.validate
 import numpydoc.tests
 
@@ -1377,7 +1378,7 @@ class TestValidator:
         ],
     )
     def test_bad_docstrings(self, capsys, klass, func, msgs):
-        with pytest.warns(None) as w:
+        with warnings.catch_warnings(record=True) as w:
             result = validate_one(self._import_path(klass=klass, func=func))
         if len(w):
             assert all('Unknown section' in str(ww.message) for ww in w)


### PR DESCRIPTION
Closes #377

Replace deprecated pytest behavior with suggested
warnings.catch_warnings.

Remove include from coverage configuration as it is ignored when
source is set.