### PR TITLE
Require sphinx>3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [Ubuntu]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        sphinx-version: ["sphinx==1.8.0", "sphinx==2.1", "sphinx>3.0"]
+        sphinx-version: ["sphinx==3.0", "sphinx==4.0", "sphinx>4.4"]
     steps:
       - uses: actions/checkout@v2
 
@@ -31,8 +31,7 @@ jobs:
           python -m pip list
 
       - name: Downgrade Jinja2 for sphinx<4
-        if: (${{ matrix.sphinx-version }} == 'sphinx==1.8.0') ||
-          (${{ matrix.sphinx-version }} == 'sphinx==2.1')
+        if: ${{ matrix.sphinx-version }} == 'sphinx<4.0.2'
         run: python -m pip install jinja2==3.0.3
 
       - name: Install

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ docstrings formatted according to the NumPy documentation format.
 The extension also adds the code description directives
 ``np:function``, ``np-c:function``, etc.
 
-numpydoc requires Python 3.7+ and sphinx 1.8+.
+numpydoc requires Python 3.7+ and sphinx 3.0+.
 
 For usage information, please refer to the `documentation
 <https://numpydoc.readthedocs.io/>`_.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,7 +5,7 @@ Getting started
 Installation
 ============
 
-This extension requires Python 3.7+, sphinx 1.8+ and is available from:
+This extension requires Python 3.7+, sphinx 3.0+ and is available from:
 
 * `numpydoc on PyPI <http://pypi.python.org/pypi/numpydoc>`_
 * `numpydoc on GitHub <https://github.com/numpy/numpydoc/>`_

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 matplotlib
 pydata-sphinx-theme<=0.8.0
-sphinx>2
+sphinx>3

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -30,8 +30,8 @@ from sphinx.addnodes import pending_xref, desc_content
 from sphinx.util import logging
 from sphinx.errors import ExtensionError
 
-if sphinx.__version__ < '1.8':
-    raise RuntimeError("Sphinx 1.8 or newer is required")
+if sphinx.__version__ < '3.0':
+    raise RuntimeError("Sphinx 3.0 or newer is required")
 
 from .docscrape_sphinx import get_doc_object
 from .validate import validate, ERROR_MSGS

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     author_email="pav@iki.fi",
     url="https://numpydoc.readthedocs.io",
     license="BSD",
-    install_requires=["sphinx>=1.8", 'Jinja2>=2.10'],
+    install_requires=["sphinx>=3.0", 'Jinja2>=2.10'],
     python_requires=">=3.7",
     extras_require={
         "testing": [


### PR DESCRIPTION
Sphinx 3.0 was released in Apr 5, 2020. Our next scheduled release is for September 2022. Sphinx 3 was the first release to officially support Python 3.7 (the minimum version of Python we officially support).

We currently don't even test with sphinx 3.

I would prefer bumping to sphinx>4.0.2, but I wanted to see what people thought about this first.