### PR TITLE
Test prereleases of requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
           python -m pip install --upgrade pip wheel setuptools
           #python -m pip install --pre -r requirements/test.txt -r doc/requirements.txt
           python -m pip install -r requirements/test.txt -r doc/requirements.txt
-          python -m pip install -U --pre sphinx pydata-sphinx-theme
+          python -m pip install -U --pre numpy sphinx pydata-sphinx-theme
           python -m pip install codecov
           python -m pip list
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,9 @@ jobs:
       - name: Setup environment
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          python -m pip install --pre -r requirements/test.txt -r doc/requirements.txt
+          #python -m pip install --pre -r requirements/test.txt -r doc/requirements.txt
+          python -m pip install -r requirements/test.txt -r doc/requirements.txt
+          python -m pip install -U --pre sphinx pydata-sphinx-theme
           python -m pip install codecov
           python -m pip list
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,3 +105,54 @@ jobs:
           echo '! python -m numpydoc numpydoc.tests.test_main._invalid_docstring' | bash
           python -m numpydoc --validate numpydoc.tests.test_main._capture_stdout
           echo '! python -m numpydoc --validate numpydoc.tests.test_main._docstring_with_errors' | bash
+
+  prerelease:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [ubuntu]
+        python-version: ["3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Python setup
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup environment
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install --pre -r requirements/test.txt -r doc/requirements.txt
+          python -m pip install codecov
+          python -m pip list
+
+      - name: Install
+        run: |
+          python -m pip install .
+          pip list
+
+      - name: Run test suite
+        run: |
+          pytest -v --pyargs .
+
+      - name: Test coverage
+        run: |
+          codecov
+
+      - name: Make sure CLI works
+        run: |
+          python -m numpydoc numpydoc.tests.test_main._capture_stdout
+          echo '! python -m numpydoc numpydoc.tests.test_main._invalid_docstring' | bash
+          python -m numpydoc --validate numpydoc.tests.test_main._capture_stdout
+          echo '! python -m numpydoc --validate numpydoc.tests.test_main._docstring_with_errors' | bash
+
+      - name: Setup for doc build
+        run: |
+          sudo apt-get update
+          sudo apt install texlive texlive-latex-extra latexmk dvipng
+
+      - name: Build documentation
+        run: |
+          make -C doc html SPHINXOPTS="-nT"
+          make -C doc latexpdf SPHINXOPTS="-nT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,9 +123,8 @@ jobs:
       - name: Setup environment
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          #python -m pip install --pre -r requirements/test.txt -r doc/requirements.txt
-          python -m pip install -r requirements/test.txt -r doc/requirements.txt
-          python -m pip install -U --pre numpy sphinx pydata-sphinx-theme
+          python -m pip install --pre -r requirements/test.txt -r doc/requirements.txt
+          python -m pip install docutils==0.17.1  # FIXME
           python -m pip install codecov
           python -m pip list
 


### PR DESCRIPTION
Since pydata-sphinx-theme is marked as "incompatible" with sphinx 5, I don't think we can use requirement files to tests pre-releases of sphinx. I've asked if they can remove the pin (which would simplify our GH action workflow):
- https://github.com/pydata/pydata-sphinx-theme/issues/660
- https://github.com/pydata/pydata-sphinx-theme/pull/661

If that PR is accepted and they make a new release at some point soon, we can just add a ``--pre`` flag and use the requirements files,