### PR TITLE
Test docutils 0.18.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install --pre -r requirements/test.txt -r doc/requirements.txt
-          python -m pip install docutils==0.17.1  # FIXME
           python -m pip install codecov
           python -m pip list
 


### PR DESCRIPTION
Sphinx 5 supports docutils 0.18.1: https://github.com/sphinx-doc/sphinx/issues/9777
and so do we #403.
