### PR TITLE
Add workaround for pytest failures on 3.11b2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,9 @@ jobs:
 
       - name: Run test suite
         run: |
-          pytest -v --pyargs numpydoc
+          # NOTE: --assert=plain necessary to work around known pytest issue.
+          # See pytest-dev/pytest#10008
+          pytest -v --pyargs --assert=plain numpydoc
 
       - name: Make sure CLI works
         run: |


### PR DESCRIPTION
Temporary workaround for pytest failures on 3.11b2. See pytest-dev/pytest#10008 and the [Python 3.11b2 release notes](https://www.python.org/downloads/release/python-3110b2/) for more info.