### PR TITLE
Require sphinx>4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,15 +13,19 @@ jobs:
       matrix:
         os: [Ubuntu]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        sphinx-version:
-          ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
-        exclude:
-          - python-version: "3.10"
-            sphinx-version: "sphinx==4.0.2"
         include:
+          - python-version: "3.7"
+            sphinx-version:
+              ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+          - python-version: "3.8"
+            sphinx-version:
+              ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+          - python-version: "3.9"
+            sphinx-version:
+              ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
           - python-version: "3.10"
-            sphinx-version: "sphinx==4.2"
-            os: [Ubuntu]
+            sphinx-version:
+              ["sphinx==4.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,13 @@ jobs:
         os: [Ubuntu]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         sphinx-version:
-          ["sphinx==4.0.3", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+          ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+        exclude:
+          - python-version: "3.10"
+            sphinx-version: "sphinx==4.0.2"
+        include:
+          - python-version: "3.10"
+            sphinx-version: "sphinx==4.2"
     steps:
       - uses: actions/checkout@v3
 
@@ -68,7 +74,7 @@ jobs:
         os: [ubuntu, macos, windows]
         python-version: ["3.11-dev"]
         sphinx-version:
-          ["sphinx==4.0.3", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+          ["sphinx==4.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         include:
           - python-version: "3.10"
             sphinx-version: "sphinx==4.2"
+            os: [Ubuntu]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         os: [Ubuntu]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         sphinx-version:
-          ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+          ["sphinx==4.0.3", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
 
@@ -68,7 +68,7 @@ jobs:
         os: [ubuntu, macos, windows]
         python-version: ["3.11-dev"]
         sphinx-version:
-          ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+          ["sphinx==4.0.3", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,20 +12,9 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        include:
-          - python-version: "3.7"
-            sphinx-version:
-              ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
-          - python-version: "3.8"
-            sphinx-version:
-              ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
-          - python-version: "3.9"
-            sphinx-version:
-              ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
-          - python-version: "3.10"
-            sphinx-version:
-              ["sphinx==4.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+        python-version: ["3.7", "3.8", "3.9"]
+        sphinx-version:
+          ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
 
@@ -72,6 +61,59 @@ jobs:
           make -C doc html SPHINXOPTS="-nT"
           make -C doc latexpdf SPHINXOPTS="-nT"
 
+  test-new:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [Ubuntu]
+        python-version: ["3.10"]
+        sphinx-version:
+          ["sphinx==4.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Python setup
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup environment
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install -r requirements/test.txt -r doc/requirements.txt
+          python -m pip install codecov
+          python -m pip install ${{ matrix.sphinx-version }}
+          python -m pip list
+
+      - name: Install
+        run: |
+          python -m pip install .
+          pip list
+
+      - name: Run test suite
+        run: |
+          pytest -v --pyargs .
+
+      - name: Test coverage
+        run: |
+          codecov
+
+      - name: Make sure CLI works
+        run: |
+          python -m numpydoc numpydoc.tests.test_main._capture_stdout
+          echo '! python -m numpydoc numpydoc.tests.test_main._invalid_docstring' | bash
+          python -m numpydoc --validate numpydoc.tests.test_main._capture_stdout
+          echo '! python -m numpydoc --validate numpydoc.tests.test_main._docstring_with_errors' | bash
+
+      - name: Setup for doc build
+        run: |
+          sudo apt-get update
+          sudo apt install texlive texlive-latex-extra latexmk dvipng
+
+      - name: Build documentation
+        run: |
+          make -C doc html SPHINXOPTS="-nT"
+          make -C doc latexpdf SPHINXOPTS="-nT"
   base:
     runs-on: ${{ matrix.os }}-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@ jobs:
       matrix:
         os: [Ubuntu]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        sphinx-version: ["sphinx==3.0", "sphinx==4.0", "sphinx>4.4"]
+        sphinx-version:
+          ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
 
@@ -29,10 +30,6 @@ jobs:
           python -m pip install codecov
           python -m pip install ${{ matrix.sphinx-version }}
           python -m pip list
-
-      - name: Downgrade Jinja2 for sphinx<4
-        if: ${{ matrix.sphinx-version }} == 'sphinx<4.0.2'
-        run: python -m pip install jinja2==3.0.3 markupsafe==2.0.1 pydata-sphinx-theme==0.8.0
 
       - name: Install
         run: |
@@ -70,7 +67,8 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         python-version: ["3.11-dev"]
-        sphinx-version: ["sphinx==4.0", "sphinx==4.5"]
+        sphinx-version:
+          ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
 
@@ -85,10 +83,6 @@ jobs:
           python -m pip install pytest pytest-cov
           python -m pip install ${{ matrix.sphinx-version }}
           python -m pip list
-
-      - name: Downgrade Jinja2 for sphinx<4
-        if: ${{ matrix.sphinx-version }} == 'sphinx<4.0.2'
-        run: python -m pip install jinja2==3.0.3 markupsafe==2.0.1 pydata-sphinx-theme==0.8.0
 
       - name: Install
         run: |

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ docstrings formatted according to the NumPy documentation format.
 The extension also adds the code description directives
 ``np:function``, ``np-c:function``, etc.
 
-numpydoc requires Python 3.7+ and sphinx 4.0.2+.
+numpydoc requires Python 3.7+ and sphinx 4.0.3+.
 
 For usage information, please refer to the `documentation
 <https://numpydoc.readthedocs.io/>`_.

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ docstrings formatted according to the NumPy documentation format.
 The extension also adds the code description directives
 ``np:function``, ``np-c:function``, etc.
 
-numpydoc requires Python 3.7+ and sphinx 3.0+.
+numpydoc requires Python 3.7+ and sphinx 4.0.2+.
 
 For usage information, please refer to the `documentation
 <https://numpydoc.readthedocs.io/>`_.

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ docstrings formatted according to the NumPy documentation format.
 The extension also adds the code description directives
 ``np:function``, ``np-c:function``, etc.
 
-numpydoc requires Python 3.7+ and sphinx 4.0.3+.
+numpydoc requires Python 3.7+ and sphinx 4.0.2+.
 
 For usage information, please refer to the `documentation
 <https://numpydoc.readthedocs.io/>`_.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,7 +5,7 @@ Getting started
 Installation
 ============
 
-This extension requires Python 3.7+, sphinx 4.0.3+ and is available from:
+This extension requires Python 3.7+, sphinx 4.0.2+ and is available from:
 
 * `numpydoc on PyPI <http://pypi.python.org/pypi/numpydoc>`_
 * `numpydoc on GitHub <https://github.com/numpy/numpydoc/>`_

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,7 +5,7 @@ Getting started
 Installation
 ============
 
-This extension requires Python 3.7+, sphinx 4.0.2+ and is available from:
+This extension requires Python 3.7+, sphinx 4.0.3+ and is available from:
 
 * `numpydoc on PyPI <http://pypi.python.org/pypi/numpydoc>`_
 * `numpydoc on GitHub <https://github.com/numpy/numpydoc/>`_

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,7 +5,7 @@ Getting started
 Installation
 ============
 
-This extension requires Python 3.7+, sphinx 3.0+ and is available from:
+This extension requires Python 3.7+, sphinx 4.0.2+ and is available from:
 
 * `numpydoc on PyPI <http://pypi.python.org/pypi/numpydoc>`_
 * `numpydoc on GitHub <https://github.com/numpy/numpydoc/>`_

--- a/numpydoc/__init__.py
+++ b/numpydoc/__init__.py
@@ -5,32 +5,6 @@ formatted according to the NumPy documentation format.
 from ._version import __version__
 
 
-def _verify_sphinx_jinja():
-    """Ensure sphinx and jinja versions are compatible.
-
-    Jinja2>=3.1 requires Sphinx>=4.0.2. Raises exception if this condition is
-    not met.
-
-    TODO: This check can be removed when the minimum supported sphinx version
-    for numpydoc sphinx>=4.0.2
-    """
-    import sphinx, jinja2
-    from packaging import version
-
-    if version.parse(sphinx.__version__) <= version.parse("4.0.2"):
-        if version.parse(jinja2.__version__) >= version.parse("3.1"):
-            from sphinx.errors import VersionRequirementError
-
-            raise VersionRequirementError(
-                "\n\nSphinx<4.0.2 is incompatible with Jinja2>=3.1.\n"
-                "If you wish to continue using sphinx<4.0.2 you need to pin "
-                "Jinja2<3.1."
-            )
-
-
-_verify_sphinx_jinja()
-
-
 def setup(app, *args, **kwargs):
     from .numpydoc import setup
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     author_email="pav@iki.fi",
     url="https://numpydoc.readthedocs.io",
     license="BSD",
-    install_requires=["sphinx>=3.0", "Jinja2>=2.10"],
+    install_requires=["sphinx>=4.0.2", "Jinja2>=2.10"],
     python_requires=">=3.7",
     extras_require={
         "testing": [

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     author_email="pav@iki.fi",
     url="https://numpydoc.readthedocs.io",
     license="BSD",
-    install_requires=["sphinx>4.0.2", "Jinja2>=2.10"],
+    install_requires=["sphinx>=4.0.2", "Jinja2>=2.10"],
     python_requires=">=3.7",
     extras_require={
         "testing": [

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     author_email="pav@iki.fi",
     url="https://numpydoc.readthedocs.io",
     license="BSD",
-    install_requires=["sphinx>=4.0.2", "Jinja2>=2.10"],
+    install_requires=["sphinx>4.0.2", "Jinja2>=2.10"],
     python_requires=">=3.7",
     extras_require={
         "testing": [


### PR DESCRIPTION
In #385, we tentatively agreed to drop support for sphinx 3 with numpy 1.4. We are releasing 1.4 a little sooner than planned.

However, the 1.4 release mainly adds support for new versions of docutils. So for folks using sphinx 3, then there is no reason for them to use numpydoc 1.4. Moreover, pydata-sphinx-theme and myst-parser have dropped support for sphinx 3 with their recent releases. Finally, in #393, you can see that numpydoc doesn't support sphinx ~= 3.5 under python 3.10 and above. You can also see in [6108474](https://github.com/numpy/numpydoc/pull/409/commits/61084740a8e1d1ffe65f5231460e33f8ae19f42f) that we require sphinx >= 4.2 under python 3.10 and above (see https://github.com/sphinx-doc/sphinx/issues/9562 for more information).

Maybe it is too aggressive, but I think it may make sense to require sphinx >= 4.2.

- sphinx 4.0.2 released May 20, 2021
- sphinx 4.2 released Sept 12, 2021

If we only require `sphinx>=4.0.2`, how should we document that for Python 3.10+ we require `sphinx>=4.2`?

Thoughts?