### PR TITLE
Require sphinx>=4.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,72 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.7", "3.8", "3.9"]
-        sphinx-version:
-          [
-            "sphinx==3.0",
-            "sphinx==3.5",
-            "sphinx==4.0",
-            "sphinx==4.5",
-            "sphinx==5.0",
-            "sphinx>=5.0",
-          ]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Python setup
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Setup environment
-        run: |
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install -r requirements/test.txt -r doc/requirements.txt
-          python -m pip install codecov
-          python -m pip install ${{ matrix.sphinx-version }}
-          python -m pip list
-
-      - name: Downgrade Jinja2 for sphinx<4
-        if: ${{ matrix.sphinx-version }} == 'sphinx<4.0.2'
-        run: python -m pip install jinja2==3.0.3 markupsafe==2.0.1 pydata-sphinx-theme==0.8.0 docutils==0.17.1
-
-      - name: Install
-        run: |
-          python -m pip install .
-          pip list
-
-      - name: Run test suite
-        run: |
-          pytest -v --pyargs .
-
-      - name: Test coverage
-        run: |
-          codecov
-
-      - name: Make sure CLI works
-        run: |
-          python -m numpydoc numpydoc.tests.test_main._capture_stdout
-          echo '! python -m numpydoc numpydoc.tests.test_main._invalid_docstring' | bash
-          python -m numpydoc --validate numpydoc.tests.test_main._capture_stdout
-          echo '! python -m numpydoc --validate numpydoc.tests.test_main._docstring_with_errors' | bash
-
-      - name: Setup for doc build
-        run: |
-          sudo apt-get update
-          sudo apt install texlive texlive-latex-extra latexmk dvipng
-
-      - name: Build documentation
-        run: |
-          make -C doc html SPHINXOPTS="-nT"
-          make -C doc latexpdf SPHINXOPTS="-nT"
-
-  test-new:
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      matrix:
-        os: [Ubuntu]
-        python-version: ["3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         sphinx-version:
           ["sphinx==4.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
@@ -125,13 +60,15 @@ jobs:
         run: |
           make -C doc html SPHINXOPTS="-nT"
           make -C doc latexpdf SPHINXOPTS="-nT"
+
   base:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
         python-version: ["3.11-dev"]
-        sphinx-version: ["sphinx==4.0", "sphinx==4.5"]
+        sphinx-version:
+          ["sphinx==4.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
 
@@ -146,10 +83,6 @@ jobs:
           python -m pip install pytest pytest-cov
           python -m pip install ${{ matrix.sphinx-version }}
           python -m pip list
-
-      - name: Downgrade Jinja2 for sphinx<4
-        if: ${{ matrix.sphinx-version }} == 'sphinx<4.0.2'
-        run: python -m pip install jinja2==3.0.3 markupsafe==2.0.1 pydata-sphinx-theme==0.8.0
 
       - name: Install
         run: |

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ docstrings formatted according to the NumPy documentation format.
 The extension also adds the code description directives
 ``np:function``, ``np-c:function``, etc.
 
-numpydoc requires Python 3.7+ and sphinx 3.0+.
+numpydoc requires Python 3.7+ and sphinx 4.2+.
 
 For usage information, please refer to the `documentation
 <https://numpydoc.readthedocs.io/>`_.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,7 +5,7 @@ Getting started
 Installation
 ============
 
-This extension requires Python 3.7+, sphinx 3.0+ and is available from:
+This extension requires Python 3.7+, sphinx 4.2+ and is available from:
 
 * `numpydoc on PyPI <http://pypi.python.org/pypi/numpydoc>`_
 * `numpydoc on GitHub <https://github.com/numpy/numpydoc/>`_

--- a/numpydoc/__init__.py
+++ b/numpydoc/__init__.py
@@ -5,32 +5,6 @@ formatted according to the NumPy documentation format.
 from ._version import __version__
 
 
-def _verify_sphinx_jinja():
-    """Ensure sphinx and jinja versions are compatible.
-
-    Jinja2>=3.1 requires Sphinx>=4.0.2. Raises exception if this condition is
-    not met.
-
-    TODO: This check can be removed when the minimum supported sphinx version
-    for numpydoc sphinx>=4.0.2
-    """
-    import sphinx, jinja2
-    from packaging import version
-
-    if version.parse(sphinx.__version__) <= version.parse("4.0.2"):
-        if version.parse(jinja2.__version__) >= version.parse("3.1"):
-            from sphinx.errors import VersionRequirementError
-
-            raise VersionRequirementError(
-                "\n\nSphinx<4.0.2 is incompatible with Jinja2>=3.1.\n"
-                "If you wish to continue using sphinx<4.0.2 you need to pin "
-                "Jinja2<3.1."
-            )
-
-
-_verify_sphinx_jinja()
-
-
 def setup(app, *args, **kwargs):
     from .numpydoc import setup
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     author_email="pav@iki.fi",
     url="https://numpydoc.readthedocs.io",
     license="BSD",
-    install_requires=["sphinx>=3.0", "Jinja2>=2.10"],
+    install_requires=["sphinx>=4.2", "Jinja2>=2.10"],
     python_requires=">=3.7",
     extras_require={
         "testing": [


### PR DESCRIPTION
Per discussion in #409, this drops support for sphinx < 4.2. Let's hold off on merging this for a week or so (to see if there are any issues with 1.4).