### PR TITLE
DOC: Add theme switcher and default to lightmode.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,10 +83,15 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "github_url": "https://github.com/numpy/numpydoc",
     "show_prev_next": False,
-    "navbar_end": ["search-field.html", "navbar-icon-links.html"],
+    "navbar_end": [
+        "theme-switcher", "search-field.html", "navbar-icon-links.html"
+    ],
 }
 html_sidebars = {
     "**": [],
+}
+html_context = {
+    "default_mode": "light",
 }
 
 html_title = f"{project} v{version} Manual"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -85,6 +85,10 @@ html_theme_options = {
     "show_prev_next": False,
     "navbar_end": ["search-field.html", "navbar-icon-links.html"],
 }
+# NOTE: The following is required for supporting of older sphinx toolchains.
+#       The "theme-switcher" templated should be added directly to navbar_end
+#       above and the following lines removed when the minimum supported
+#       version of pydata_sphinx_theme is 0.9.0
 # Add version switcher for versions of pydata_sphinx_theme that support it
 import packaging
 import pydata_sphinx_theme
@@ -93,6 +97,7 @@ if packaging.version.parse(pydata_sphinx_theme.__version__) >= packaging.version
     "0.9.0"
 ):
     html_theme_options["navbar_end"].insert(0, "theme-switcher")
+
 
 html_sidebars = {
     "**": [],

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,8 +83,17 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "github_url": "https://github.com/numpy/numpydoc",
     "show_prev_next": False,
-    "navbar_end": ["theme-switcher", "search-field.html", "navbar-icon-links.html"],
+    "navbar_end": ["search-field.html", "navbar-icon-links.html"],
 }
+# Add version switcher for versions of pydata_sphinx_theme that support it
+import packaging
+import pydata_sphinx_theme
+
+if packaging.version.parse(pydata_sphinx_theme.__version__) >= packaging.version.parse(
+    "0.9.0"
+):
+    html_theme_options["navbar_end"].insert(0, "theme-switcher")
+
 html_sidebars = {
     "**": [],
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,9 +83,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "github_url": "https://github.com/numpy/numpydoc",
     "show_prev_next": False,
-    "navbar_end": [
-        "theme-switcher", "search-field.html", "navbar-icon-links.html"
-    ],
+    "navbar_end": ["theme-switcher", "search-field.html", "navbar-icon-links.html"],
 }
 html_sidebars = {
     "**": [],


### PR DESCRIPTION
Adds the widget for toggling the documentation theme from dark mode to light mode. Also defaults to lightmode to be consistent with the main numpy documentation.

Closes #413