### PR TITLE
docs: fix validation include line numbers

### DIFF
--- a/doc/validation.rst
+++ b/doc/validation.rst
@@ -64,5 +64,5 @@ a more detailed message. For example::
 The full mapping of validation checks is given below.
 
 .. literalinclude:: ../numpydoc/validate.py
-   :start-after: [validate-docs]
-   :end-before: [validate-docs]
+   :start-after: start-err-msg
+   :end-before: end-err-msg

--- a/doc/validation.rst
+++ b/doc/validation.rst
@@ -64,4 +64,5 @@ a more detailed message. For example::
 The full mapping of validation checks is given below.
 
 .. literalinclude:: ../numpydoc/validate.py
-   :lines: 37-93
+   :start-after: [validate-docs]
+   :end-before: [validate-docs]

--- a/doc/validation.rst
+++ b/doc/validation.rst
@@ -64,4 +64,4 @@ a more detailed message. For example::
 The full mapping of validation checks is given below.
 
 .. literalinclude:: ../numpydoc/validate.py
-   :lines: 36-90
+   :lines: 37-93

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -34,6 +34,9 @@ ALLOWED_SECTIONS = [
     "References",
     "Examples",
 ]
+# NOTE: The following comment is a sentinel for embedding in the docs - do not
+# modify/remove
+# start-err-msg
 ERROR_MSGS = {
     "GL01": "Docstring text (summary) should start in the line immediately "
     "after the opening quotes (not in the same line, or leaving a "
@@ -91,6 +94,9 @@ ERROR_MSGS = {
     "SA04": 'Missing description for See Also "{reference_name}" reference',
     "EX01": "No examples section found",
 }
+# end-err-msg
+# NOTE: The above comment is a sentinel for embedding in the docs - do not
+# modify/remove
 
 # Ignore these when evaluating end-of-line-"." checks
 IGNORE_STARTS = (" ", "* ", "- ")


### PR DESCRIPTION
A small PR to fix the line numbers being included from the validate.py file. (currently ERROR_MSGS is not showing up properly on the docs)