### PR TITLE
[DOC] Describe how to include parameter sizes & shapes

### DIFF
--- a/doc/format.rst
+++ b/doc/format.rst
@@ -211,6 +211,20 @@ used as a value, ``optional`` is preferred. These are all equivalent::
   copy : bool, default=True
   copy : bool, default: True
 
+If the shapes and sizes of the parameters are related, that information
+should be included in parentheses at the beginning of the type line. A
+trailing comma should be included inside the parentheses if the
+parameter is 1D::
+
+   Parameters
+   ----------
+   a : (M,) array_like
+       First input vector.
+   b : (N,) array_like
+       Second input vector.
+   out : (M, N) ndarray, optional
+       A location where the result is stored
+
 When a parameter can only assume one of a fixed set of values,
 those values can be listed in braces, with the default appearing first::
 


### PR DESCRIPTION
This pull request describes how to include size & shape information for a parameter in the type line of the **Parameters** section of docstrings.  I adapted the example from [`numpy.outer`](https://github.com/numpy/numpy/blob/54c52f13713f3d21795926ca4dbb27e16fada171/numpy/core/numeric.py#L857-L942).  

I decided to place the size & shape information at the beginning of the type information because:
 - It is currently used this way in NumPy, at least occasionally.
 - Aligning this information at the beginning makes it easier to see the relationships between the different parameters when skimming through the list. This also has the benefit that the parameter name and size information are right next to each other, which makes it easier to grasp the relationships between the sizes & shapes of the different parameters and return values.

Some of the alternatives I considered were:
 - _Include sizes & shapes at the end of the type description rather than at the beginning._  I didn't choose this because the size & shapes were less aligned this way, which made it harder to grasp the relationships between the different parameters.
 - _Allow the size & shape info to be included either at the beginning or the end of the type information._ I didn't do this because having one way to do it will lead to greater standardization, which will lead to greater consistency.
 - _Have the size & shape be specified in the parameter description._ I didn't do this because the size & shape info would be further separated from the parameter name which would make it harder to grasp the relationships between different parameters. 
 - Not include size & shape info be included in the standard.  I don't prefer this because it's pretty common to have to do this, and in my experience this info ends up being included fairly inconsistently, even in a single project, and especially across multiple projects.  Having a specification for this would also make it easier to write linters and autoformatters for docstrings in the numpydoc style.

Thanks!