### PR TITLE
DOC: Use `:ref:` when referring to section headers

### DIFF
--- a/doc/format.rst
+++ b/doc/format.rst
@@ -31,7 +31,7 @@ Use a code checker:
  * pyflakes_: a tool to check Python code for errors by parsing
    the source file instead of importing it.
  * pycodestyle_: (formerly ``pep8``) a tool to check Python code against
-   some of the style conventions in PEP 8.
+   some of the style conventions in :pep:`8`.
  * flake8_: a tool that glues together ``pycodestyle``, ``pyflakes``,
    ``mccabe`` to check the style and quality of Python code.
  * vim-flake8_: a ``flake8`` plugin for Vim.
@@ -291,10 +291,12 @@ Support for the :ref:`Yields <yields>` section was added in `numpydoc
 ```````````
 
 Explanation of parameters passed to a generator's ``.send()`` method,
-formatted as for Parameters, above.  Since, like for Yields and Returns, a
-single object is always passed to the method, this may describe either the
-single parameter, or positional arguments passed as a tuple.  If a docstring
-includes Receives it must also include Yields.
+formatted as for :ref:`Parameters <parameters>`, above.  Since, like for
+:ref:`Yields <yields>` and :ref:`Returns <returns>`, a single object is
+always passed to the method, this may describe either the single parameter,
+or positional arguments passed as a tuple.  If a docstring
+includes :ref:`Receives <receives>` it must also include
+:ref:`Yields <yields>`.
 
 8. Other Parameters
 ```````````````````
@@ -321,7 +323,7 @@ that are non-obvious or have a large chance of getting raised.
 `````````
 
 An optional section detailing which warnings get raised and
-under what conditions, formatted similarly to Raises.
+under what conditions, formatted similarly to :ref:`Raises <raises>`.
 
 11. Warnings
 ````````````
@@ -545,8 +547,8 @@ Documenting classes
 
 Class docstring
 ```````````````
-Use the same sections as outlined above (all except ``Returns`` are
-applicable).  The constructor (``__init__``) should also be documented
+Use the same sections as outlined above (all except :ref:`Returns <returns>`
+are applicable).  The constructor (``__init__``) should also be documented
 here, the :ref:`Parameters <params>` section of the docstring details the
 constructor's parameters.
 

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -287,11 +287,13 @@ takes the same form as the :ref:`Returns <returns>` section::
 Support for the :ref:`Yields <yields>` section was added in `numpydoc
 <https://github.com/numpy/numpydoc>`_ version 0.6.
 
+.. _receives:
+
 7. Receives
 ```````````
 
 Explanation of parameters passed to a generator's ``.send()`` method,
-formatted as for :ref:`Parameters <parameters>`, above.  Since, like for
+formatted as for :ref:`Parameters <params>`, above.  Since, like for
 :ref:`Yields <yields>` and :ref:`Returns <returns>`, a single object is
 always passed to the method, this may describe either the single parameter,
 or positional arguments passed as a tuple.  If a docstring
@@ -304,6 +306,8 @@ includes :ref:`Receives <receives>` it must also include
 An optional section used to describe infrequently used parameters.
 It should only be used if a function has a large number of keyword
 parameters, to prevent cluttering the :ref:`Parameters <params>` section.
+
+.. _raises:
 
 9. Raises
 `````````


### PR DESCRIPTION
This PR makes a few minor changes to more consistently use the `:ref:` role to link to different sections in different parts of the numpydoc standard.

I also used the [`:pep:`](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-pep) role to create a link to PEP 8.