### PR TITLE
ENH: Update validate.py to allow parameters with trailing underscores.

### DIFF
--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -1144,6 +1144,7 @@ class TestValidator:
             "other_parameters",
             "warnings",
             "valid_options_in_parameter_description_sets",
+            "parameters_with_trailing_underscores",
         ],
     )
     def test_good_functions(self, capsys, func):

--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -485,7 +485,7 @@ class GoodDocStrings:
     def parameters_with_trailing_underscores(self, str_):
         r"""
         Ensure PR01 and PR02 errors are not raised with trailing underscores.
-        
+
         Parameters with trailing underscores need to be escaped to render
         properly in the documentation since trailing underscores are used to
         create links. Doing so without also handling the change in the validation
@@ -504,7 +504,7 @@ class GoodDocStrings:
         --------
         >>> result = 1 + 1
         """
-        pass       
+        pass
 
 
 class BadGenericDocStrings:

--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -486,9 +486,10 @@ class GoodDocStrings:
         r"""
         Ensure PR01 and PR02 errors are not raised with trailing underscores.
         
-        Parameters with trailing underscores need to escape the them to render
+        Parameters with trailing underscores need to be escaped to render
         properly in the documentation since trailing underscores are used to
-        create links.
+        create links. Doing so without also handling the change in the validation
+        logic makes it impossible to both pass validation and render correctly.
 
         Parameters
         ----------

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -330,7 +330,7 @@ class Validator:
     def parameter_mismatches(self):
         errs = []
         signature_params = self.signature_parameters
-        all_params = tuple(self.doc_all_parameters)
+        all_params = tuple(param.replace("\\", "") for param in self.doc_all_parameters)
         missing = set(signature_params) - set(all_params)
         if missing:
             errs.append(error("PR01", missing_params=str(missing)))


### PR DESCRIPTION
In https://github.com/numpy/numpydoc/issues/62, https://github.com/numpy/numpydoc/pull/144, and https://github.com/numpy/numpydoc/pull/63, changes are discussed for rendering parameters with trailing underscores; however, the `validate.py` logic doesn't seem to be compatible.

Given a docstring like the following the validation logic currently reports PR01 "Parameters {'type_'} not documented" and PR02 "Unknown parameters {'type\\_'}" because it doesn't handle the escape character:
```python
def test_func(type_):
    r"""
    Test the docstring.

    Parameters
    ----------
    type\_ : str
       Some description.
    """
    pass
   ```
 
On the flip side, removing the escape character passes the validation checks, but does not render properly in the docs (renders as `type` instead of `type_`).