### PR TITLE
BUG: Fix returns parsing no name

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -226,10 +226,14 @@ class NumpyDocString(Mapping):
         params = []
         while not r.eof():
             header = r.read().strip()
-            if " :" in header:
-                arg_name, arg_type = header.split(" :", maxsplit=1)
-                arg_name, arg_type = arg_name.strip(), arg_type.strip()
+            if " : " in header:
+                arg_name, arg_type = header.split(" : ", maxsplit=1)
             else:
+                # NOTE: param line with single element should never have a
+                # a " :" before the description line, so this should probably
+                # warn.
+                if header.endswith(" :"):
+                    header = header[:-2]
                 if single_element_is_type:
                     arg_name, arg_type = "", header
                 else:

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -980,6 +980,21 @@ doc8 = NumpyDocString(
 )
 
 
+def test_returns_with_roles_no_names():
+    """Make sure colons that are part of sphinx roles are not misinterpreted
+    as type separator in returns section. See gh-428."""
+    docstring = NumpyDocString(
+        """
+        Returns
+        -------
+        str or :class:`NumpyDocString`
+        """
+    )
+    expected = "str or :class:`NumpyDocString`"  # not "str or : class:...
+    assert docstring["Returns"][0].type == expected
+    assert expected in str(docstring)
+
+
 def test_trailing_colon():
     assert doc8["Parameters"][0].name == "data"
 


### PR DESCRIPTION
Update to the parameter line parsing to fix #428 

IIUC, the change in the parameter line parsing introduced in #286 was intended to handle the case when parameter lines end in a ` :`. These changes preserve that behavior, while fixing a defect related to role parsing on parameter lines.

Technically, lines that end in ` :` prior to the description don't conform to the standard, so that case should probably also emit a warning. I'd like to save that for a follow-up PR though and do a little legwork to see how disruptive that would be. For now, I've left a comment (happy to remove if desired).