### PR TITLE
Change PR06 logic to only fail when type is used standalone

### DIFF
--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -506,6 +506,40 @@ class GoodDocStrings:
         """
         pass
 
+    def parameter_with_wrong_types_as_substrings(self, a, b, c, d, e, f):
+        r"""
+        Ensure PR06 doesn't fail when non-preferable types are substrings.
+
+        While PR06 checks for parameter types which contain non-preferable type
+        names like integer (int), string (str), and boolean (bool), PR06 should
+        not fail if those types are used only as susbtrings in, for example,
+        custom type names.
+
+        Parameters
+        ----------
+        a : Myint
+           Some text.
+        b : intClass
+           Some text.
+        c : Mystring
+           Some text.
+        d : stringClass
+           Some text.
+        e : Mybool
+           Some text.
+        f : boolClass
+           Some text.
+
+        See Also
+        --------
+        related : Something related.
+
+        Examples
+        --------
+        >>> result = 1 + 1
+        """
+        pass
+
 
 class BadGenericDocStrings:
     """Everything here has a bad docstring"""
@@ -1145,6 +1179,7 @@ class TestValidator:
             "warnings",
             "valid_options_in_parameter_description_sets",
             "parameters_with_trailing_underscores",
+            "parameter_with_wrong_types_as_substrings",
         ],
     )
     def test_good_functions(self, capsys, func):

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -584,7 +584,15 @@ def validate(obj_name):
                     ("string", "str"),
                 ]
                 for wrong_type, right_type in common_type_errors:
-                    if wrong_type in doc.parameter_type(param):
+                    param_type = doc.parameter_type(param)
+                    if wrong_type in param_type:
+                        # Ignore if wrong_type is used as a substring
+                        if (
+                            re.match(f"\w+{wrong_type}", param_type) or
+                            re.match(f"{wrong_type}\w+", param_type)
+                           ):
+                            continue
+
                         errs.append(
                             error(
                                 "PR06",

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -584,15 +584,8 @@ def validate(obj_name):
                     ("string", "str"),
                 ]
                 for wrong_type, right_type in common_type_errors:
-                    param_type = doc.parameter_type(param)
-                    if wrong_type in param_type:
-                        # Ignore if wrong_type is used as a substring
-                        if (
-                            re.match(f"\w+{wrong_type}", param_type) or
-                            re.match(f"{wrong_type}\w+", param_type)
-                           ):
-                            continue
-
+                    if wrong_type in set(re.split(r"\W", doc.parameter_type(
+                            param))):
                         errs.append(
                             error(
                                 "PR06",

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -584,8 +584,7 @@ def validate(obj_name):
                     ("string", "str"),
                 ]
                 for wrong_type, right_type in common_type_errors:
-                    if wrong_type in set(re.split(r"\W", doc.parameter_type(
-                            param))):
+                    if wrong_type in set(re.split(r"\W", doc.parameter_type(param))):
                         errs.append(
                             error(
                                 "PR06",


### PR DESCRIPTION
Closes https://github.com/numpy/numpydoc/issues/446

This is a draft PR for addressing https://github.com/numpy/numpydoc/issues/446 which hasn't yet been discussed. For reviewing, I'd pay special attention to how I went the logic in `validate.py`, especially the regex. 