### PR TITLE
MAINT: Fix CIs for sphinx 6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: numpydoc tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]
@@ -55,6 +59,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt install texlive texlive-latex-extra latexmk dvipng
+          pip install "sphinx<6"
 
       - name: Build documentation
         run: |
@@ -106,6 +111,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt install texlive texlive-latex-extra latexmk dvipng
+          pip install "sphinx<6"
 
       - name: Build documentation
         run: |

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,4 +1,5 @@
 numpy>=1.21
 matplotlib>=3.5
 pydata-sphinx-theme>=0.11
-sphinx>=5.2
+# TODO: Remove <6 here and in actions when pydata-sphinx-theme handles sphinx 6
+sphinx>=5.2,<6


### PR DESCRIPTION
Let's see if this fixes CIs -- pin to `< 6` when running `make html`

Also sneaks in a `concurrency` group to save CI resources in case people push repeatedly / quickly