### PR TITLE
Update blacken-docs repo after owner transfer.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         files: \.(html|md|yml|yaml)
         args: [--prose-wrap=preserve]
 
-  - repo: https://github.com/asottile/blacken-docs
+  - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.13.0
     hooks:
       - id: blacken-docs


### PR DESCRIPTION
The `blacken-docs` repo was transferred to a new owner at the end of 2022 ([source](https://github.com/adamchainz/blacken-docs#history)). If you visit the original repository, it now redirects to https://github.com/adamchainz/blacken-docs.