### PR TITLE
Require Sphinx 5+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,23 +16,25 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         sphinx-version:
           [
-            "sphinx==4.2",
-            "sphinx==4.5",
             "sphinx==5.0",
             "sphinx==5.3",
             "sphinx==6.0",
-            "sphinx>6.0",
+            "sphinx==6.2",
+            "sphinx>=7.0",
           ]
         exclude:
           - os: Ubuntu
             python-version: "3.7"
             sphinx-version: "sphinx==6.0"
-          - os: Ubuntu
+          - os: ubuntu
             python-version: "3.7"
-            sphinx-version: "sphinx>6.0"
+            sphinx-version: "sphinx==6.2"
+          - os: ubuntu
+            python-version: "3.7"
+            sphinx-version: "sphinx>=7.0"
     steps:
       - uses: actions/checkout@v3
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ docstrings formatted according to the NumPy documentation format.
 The extension also adds the code description directives
 ``np:function``, ``np-c:function``, etc.
 
-numpydoc requires Python 3.7+ and sphinx 4.2+.
+numpydoc requires Python 3.7+ and sphinx 5+.
 
 For usage information, please refer to the `documentation
 <https://numpydoc.readthedocs.io/>`_.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,7 +5,7 @@ Getting started
 Installation
 ============
 
-This extension requires Python 3.7+, sphinx 4.2+ and is available from:
+This extension requires Python 3.7+, sphinx 5+ and is available from:
 
 * `numpydoc on PyPI <http://pypi.python.org/pypi/numpydoc>`_
 * `numpydoc on GitHub <https://github.com/numpy/numpydoc/>`_

--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -30,8 +30,8 @@ from sphinx.addnodes import pending_xref, desc_content
 from sphinx.util import logging
 from sphinx.errors import ExtensionError
 
-if sphinx.__version__ < "4.2":
-    raise RuntimeError("Sphinx 4.2 or newer is required")
+if sphinx.__version__ < "5":
+    raise RuntimeError("Sphinx 5 or newer is required")
 
 from .docscrape_sphinx import get_doc_object
 from .validate import validate, ERROR_MSGS

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     author_email="pav@iki.fi",
     url="https://numpydoc.readthedocs.io",
     license="BSD",
-    install_requires=["sphinx>=4.2", "Jinja2>=2.10"],
+    install_requires=["sphinx>=5", "Jinja2>=2.10"],
     python_requires=">=3.7",
     extras_require={
         "testing": [


### PR DESCRIPTION
It has been a year since we updated our minimum Sphinx dependency. I am doing this in preparation for releasing 1.6 soon and will be making a few more janitorial cleanup PRs.