### PR TITLE
Drop Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         sphinx-version:
           [
             "sphinx==5.0",
@@ -25,16 +25,6 @@ jobs:
             "sphinx==6.2",
             "sphinx>=7.0",
           ]
-        exclude:
-          - os: Ubuntu
-            python-version: "3.7"
-            sphinx-version: "sphinx==6.0"
-          - os: ubuntu
-            python-version: "3.7"
-            sphinx-version: "sphinx==6.2"
-          - os: ubuntu
-            python-version: "3.7"
-            sphinx-version: "sphinx>=7.0"
     steps:
       - uses: actions/checkout@v3
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,4 +37,4 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ docstrings formatted according to the NumPy documentation format.
 The extension also adds the code description directives
 ``np:function``, ``np-c:function``, etc.
 
-numpydoc requires Python 3.7+ and sphinx 5+.
+numpydoc requires Python 3.8+ and sphinx 5+.
 
 For usage information, please refer to the `documentation
 <https://numpydoc.readthedocs.io/>`_.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,7 +5,7 @@ Getting started
 Installation
 ============
 
-This extension requires Python 3.7+, sphinx 5+ and is available from:
+This extension requires Python 3.8+, sphinx 5+ and is available from:
 
 * `numpydoc on PyPI <http://pypi.python.org/pypi/numpydoc>`_
 * `numpydoc on GitHub <https://github.com/numpy/numpydoc/>`_

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -11,12 +11,7 @@ from collections.abc import Callable, Mapping
 import copy
 import sys
 
-
-# TODO: Remove try-except when support for Python 3.7 is dropped
-try:
-    from functools import cached_property
-except ImportError:  # cached_property added in Python 3.8
-    cached_property = property
+from functools import cached_property
 
 
 def strip_blank_lines(l):

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from copy import deepcopy
 import re
-import sys
 import textwrap
 import warnings
 
@@ -1624,9 +1623,6 @@ def test__error_location_no_name_attr():
         nds._error_location(msg=msg)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 8), reason="cached_property was added in 3.8"
-)
 def test_class_docstring_cached_property():
     """Ensure that properties marked with the `cached_property` decorator
     are listed in the Methods section. See gh-432."""

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ with open(os.path.join("numpydoc", "_version.py")) as fid:
 if version is None:
     raise RuntimeError("Could not determine version")
 
-if sys.version_info < (3, 7):
-    raise RuntimeError("Python version >= 3.7 required.")
+if sys.version_info < (3, 8):
+    raise RuntimeError("Python version >= 3.8 required.")
 
 
 def read(fname):
@@ -42,7 +42,6 @@ setup(
         "Topic :: Documentation",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -54,7 +53,7 @@ setup(
     url="https://numpydoc.readthedocs.io",
     license="BSD",
     install_requires=["sphinx>=5", "Jinja2>=2.10"],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     extras_require={
         "testing": [
             req


### PR DESCRIPTION
Python 3.7 security support will be dropped in about two weeks (27 Jun 2023). NEP29 and SPEC0 already recommended projects in the ecosystem drop Python 3.7 support.