### PR TITLE
Use rtd template (old method is deprecated)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,31 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "doc/" directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: requirements/doc.txt

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -46,7 +46,7 @@ Process
 - Publish on PyPi::
 
     git clean -fxd
-    pip install build wheel twine
+    pip install --upgrade build wheel twine
     python -m build --sdist --wheel
     twine upload -s dist/*
 


### PR DESCRIPTION
Close #471 

Our doc builds are failing:
https://readthedocs.org/projects/numpydoc/builds/

According to https://blog.readthedocs.com/migrate-configuration-v2/

```
Monday, September 25, 2023: Fully remove support for building documentation without configuration file v2.
```

Here is the documentation for the new configuration file: https://docs.readthedocs.io/en/stable/config-file/v2.html