### PR TITLE
Install package on rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,4 +28,7 @@ sphinx:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-    - requirements: requirements/doc.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,11 @@ setup(
             for req in read("requirements/test.txt").split("\n")
             if not req.startswith("#")
         ],
+        "doc": [
+            req
+            for req in read("requirements/doc.txt").split("\n")
+            if not req.startswith("#")
+        ],
     },
     package_data={
         "numpydoc": [


### PR DESCRIPTION
Close #471 

I am following this guide
https://docs.readthedocs.io/en/stable/config-file/v2.html#packages

With the intent that it install like this
```
$ pip install .[doc]
```