### PR TITLE
Fix dynamic version specification.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ packages = [
     'numpydoc',
     'numpydoc.hooks',
 ]
+[tool.setuptools.dynamic.version]
+attr = 'numpydoc.__version__'
 
 [tool.setuptools.package-data]
 numpydoc = [

--- a/tools/pyproject.toml.in
+++ b/tools/pyproject.toml.in
@@ -53,6 +53,9 @@ packages = [
 ]
 include-package-data = false
 
+[tool.setuptools.dynamic]
+version = {attr = "numpydoc.__version__"}
+
 [tool.setuptools.package-data]
 numpydoc = [
     "tests/test_*.py",


### PR DESCRIPTION
I noticed a small bug coming from https://github.com/numpy/numpydoc/pull/474. In order to use the dynamic version, you have to specify where it is coming from otherwise it installs as `numpydoc-0.0.0`. I added the required logic to the `tools/pyproject.toml.in` file and ran the script to update the file.

Before change:

`Successfully installed numpydoc-0.0.0`

After change:

`Successfully installed numpydoc-1.6.0rc1.dev0`
