### PR TITLE
Add config for pre-commit bot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,12 @@ repos:
         language: system
         entry: python tools/generate_requirements.py
         files: "pyproject.toml|requirements/.*\\.txt|tools/generate_requirements.py"
+
+ci:
+  # This ensures that pr's aren't autofixed by the bot, rather you call
+  # the bot to make the fix
+  autofix_prs: false
+  autofix_commit_msg: |
+    '[pre-commit.ci 🤖] Apply code format tools to PR'
+  # Update hook versions every month (so we don't get hit with weekly update pr's)
+  autoupdate_schedule: monthly


### PR DESCRIPTION
@larsoner On other projects, I've used this configuration for the pre-commit.ci bot. I am not sure how it works without the config. Thoughts or suggestions?