### PR TITLE
TST: Test no-file for source

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -4,8 +4,10 @@ on:
   pull_request:
     types:
       - opened
+      - repoened
       - labeled
       - unlabeled
+      - synchronize
 
 env:
   LABELS: ${{ join( github.event.pull_request.labels.*.name, ' ' ) }}

--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -41,6 +41,33 @@ def test_get_validation_checks_validity(checks):
         _ = validate.get_validation_checks(checks)
 
 
+class _DummyList(list):
+    """Dummy list class to test validation."""
+
+
+def test_no_file():
+    """Test that validation can be done on functions made on the fly."""
+    # Just a smoke test for now, <list> will have a None filename
+    validate.validate("numpydoc.tests.test_validate._DummyList.clear")
+    # This does something like decorator.FunctionMaker.make
+    src = """\
+def func():
+    '''Do something.'''
+    return 1
+"""
+    evaldict = {}
+    exec(compile(src, "<string>", "single"), evaldict)
+    func = evaldict["func"]
+    func.__source__ = src
+    func.__module__ = "numpydoc.tests.test_validate"
+    assert func() == 1
+    # This should get past the comment reading at least. A properly
+    # wrapped function *would* have source code, too. We could add such
+    # a test later
+    with pytest.raises(OSError, match="could not get source code"):
+        validate.validate(validate.get_doc_object(func))
+
+
 @pytest.mark.parametrize(
     ["file_contents", "expected"],
     [

--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -49,23 +49,6 @@ def test_no_file():
     """Test that validation can be done on functions made on the fly."""
     # Just a smoke test for now, <list> will have a None filename
     validate.validate("numpydoc.tests.test_validate._DummyList.clear")
-    # This does something like decorator.FunctionMaker.make
-    src = """\
-def func():
-    '''Do something.'''
-    return 1
-"""
-    evaldict = {}
-    exec(compile(src, "<string>", "single"), evaldict)
-    func = evaldict["func"]
-    func.__source__ = src
-    func.__module__ = "numpydoc.tests.test_validate"
-    assert func() == 1
-    # This should get past the comment reading at least. A properly
-    # wrapped function *would* have source code, too. We could add such
-    # a test later
-    with pytest.raises(OSError, match="could not get source code"):
-        validate.validate(validate.get_doc_object(func))
 
 
 @pytest.mark.parametrize(

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from typing import Dict, List, Set, Optional
 import ast
 import collections
+import functools
 import importlib
 import inspect
 import os
@@ -111,6 +112,12 @@ IGNORE_STARTS = (" ", "* ", "- ")
 IGNORE_COMMENT_PATTERN = re.compile("(?:.* numpydoc ignore[=|:] ?)(.+)")
 
 
+# This function gets called once per function/method to be validated.
+# We have to balance memory usage with performance here. It shouldn't be too
+# bad to store these `dict`s (they should be rare), but to be safe let's keep
+# the limit low-ish. This was set by looking at scipy, numpy, matplotlib,
+# and pandas and they had between ~500 and ~1300 .py files as of 2023-08-16.
+@functools.lru_cache(maxsize=2000)
 def extract_ignore_validation_comments(
     filepath: Optional[os.PathLike],
 ) -> Dict[int, List[str]]:

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -7,7 +7,7 @@ with all the detected errors.
 """
 
 from copy import deepcopy
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Optional
 import ast
 import collections
 import importlib
@@ -111,7 +111,9 @@ IGNORE_STARTS = (" ", "* ", "- ")
 IGNORE_COMMENT_PATTERN = re.compile("(?:.* numpydoc ignore[=|:] ?)(.+)")
 
 
-def extract_ignore_validation_comments(filepath: os.PathLike) -> Dict[int, List[str]]:
+def extract_ignore_validation_comments(
+    filepath: Optional[os.PathLike],
+) -> Dict[int, List[str]]:
     """
     Extract inline comments indicating certain validation checks should be ignored.
 
@@ -125,8 +127,12 @@ def extract_ignore_validation_comments(filepath: os.PathLike) -> Dict[int, List[
     dict[int, list[str]]
         Mapping of line number to a list of checks to ignore.
     """
-    with open(filepath) as file:
-        numpydoc_ignore_comments = {}
+    numpydoc_ignore_comments = {}
+    try:
+        file = open(filepath)
+    except (OSError, TypeError):  # can be None, nonexistent, or unreadable
+        return numpydoc_ignore_comments
+    with file:
         last_declaration = 1
         declarations = ["def", "class"]
         for token in tokenize.generate_tokens(file.readline):


### PR DESCRIPTION
Not sure this is the best solution but it at least allows things in MNE-Python to pass. Turns out the real issue was us subclassing `list` and that having to associated `file`. But I added another test that failed a different way along the way as well for where we create functions dynamically.

cc @stefmolin @stefanv since you've probably thought about this more than I have! And @jarrodmillman since we should probably get some form of this in for 1.6.

BTW the time to test docstrings in MNE-python went from this before #476:
```
5.15s call     mne/tests/test_docstring_parameters.py::test_docstring_parameters
```
to:
```
49.58s call     mne/tests/test_docstring_parameters.py::test_docstring_parameters
```
So we should indeed prioritize time/efficiency at some point soon :)