### PR TITLE
Fix clean_backref for extensions that have backrefs to inline elements.

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -24,7 +24,7 @@ from collections.abc import Callable
 import hashlib
 import itertools
 
-from docutils.nodes import citation, Text, section, comment, reference
+from docutils.nodes import citation, Text, section, comment, reference, inline
 import sphinx
 from sphinx.addnodes import pending_xref, desc_content
 from sphinx.util import logging
@@ -147,6 +147,10 @@ def clean_backrefs(app, doc, docname):
     # only::latex directive has resulted in citation backrefs without reference
     known_ref_ids = set()
     for ref in _traverse_or_findall(doc, reference, descend=True):
+        for id_ in ref["ids"]:
+            known_ref_ids.add(id_)
+    # some extensions produce backrefs to inline elements
+    for ref in _traverse_or_findall(doc, inline, descend=True):
         for id_ in ref["ids"]:
             known_ref_ids.add(id_)
     for citation_node in _traverse_or_findall(doc, citation, descend=True):

--- a/numpydoc/tests/test_numpydoc.py
+++ b/numpydoc/tests/test_numpydoc.py
@@ -3,7 +3,11 @@ from collections import defaultdict
 from io import StringIO
 from pathlib import PosixPath
 from copy import deepcopy
-from numpydoc.numpydoc import mangle_docstrings, _clean_text_signature, update_config
+
+from docutils import nodes
+
+from numpydoc.numpydoc import mangle_docstrings, _clean_text_signature, \
+    update_config, clean_backrefs
 from numpydoc.xref import DEFAULT_LINKS
 from sphinx.ext.autodoc import ALL
 from sphinx.util import logging
@@ -260,6 +264,21 @@ def test_update_config_exclude_str():
     app.config.numpydoc_validation_exclude = "shouldnt-be-a-str"
     with pytest.raises(ValueError, match=r"\['shouldnt-be-a-str'\]"):
         update_config(app)
+
+
+def test_clean_backrefs():
+    """Check ids are not cleaned from inline backrefs."""
+    par = nodes.paragraph(rawsource="", text="")
+    inline_ref = nodes.inline(rawsource="", text="", ids=["id1"])
+    inline_ref += nodes.reference(rawsource="", text="[1]", refid="r123-1")
+    citation = nodes.citation(
+        rawsource="", docname="index", backrefs=["id1"], ids=["r123-1"])
+    citation += nodes.label("1")
+    citation += nodes.paragraph(rawsource="", text="Author. Title.")
+    par += inline_ref
+    par += citation
+    clean_backrefs(app=MockApp(), doc=par, docname="index")
+    assert "id1" in citation["backrefs"]
 
 
 if __name__ == "__main__":

--- a/numpydoc/tests/test_numpydoc.py
+++ b/numpydoc/tests/test_numpydoc.py
@@ -6,8 +6,12 @@ from copy import deepcopy
 
 from docutils import nodes
 
-from numpydoc.numpydoc import mangle_docstrings, _clean_text_signature, \
-    update_config, clean_backrefs
+from numpydoc.numpydoc import (
+    mangle_docstrings,
+    _clean_text_signature,
+    update_config,
+    clean_backrefs,
+)
 from numpydoc.xref import DEFAULT_LINKS
 from sphinx.ext.autodoc import ALL
 from sphinx.util import logging
@@ -272,7 +276,8 @@ def test_clean_backrefs():
     inline_ref = nodes.inline(rawsource="", text="", ids=["id1"])
     inline_ref += nodes.reference(rawsource="", text="[1]", refid="r123-1")
     citation = nodes.citation(
-        rawsource="", docname="index", backrefs=["id1"], ids=["r123-1"])
+        rawsource="", docname="index", backrefs=["id1"], ids=["r123-1"]
+    )
     citation += nodes.label("1")
     citation += nodes.paragraph(rawsource="", text="Author. Title.")
     par += inline_ref


### PR DESCRIPTION
Originally reported here:

https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/277