### PR TITLE
during tokenize, use UTF8 encoding on all platforms

### DIFF
--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -96,7 +96,7 @@ def test_extract_ignore_validation_comments(tmp_path, file_contents, expected):
 @pytest.mark.parametrize(
     ("classname", "actual_encoding"),
     (
-        pytest.param("MÿClass", "cp1252", id="cp12542_file"),
+        pytest.param("MÿClass", "cp1252", id="cp1252_file"),
         pytest.param("My\u0081Class", "utf-8", id="utf8_file"),
     ),
 )

--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -86,22 +86,45 @@ def test_extract_ignore_validation_comments(tmp_path, file_contents, expected):
     assert validate.extract_ignore_validation_comments(filepath) == expected
 
 
-@pytest.mark.parametrize("assumed_encoding", ("latin-1", "utf-8"))
-def test_non_utf8_encoding(tmp_path, assumed_encoding):
+@pytest.mark.parametrize(
+    "assumed_encoding",
+    (
+        pytest.param("utf-8", id="utf8_codec"),
+        pytest.param("cp1252", id="cp1252_codec"),
+    ),
+)
+@pytest.mark.parametrize(
+    ("classname", "actual_encoding"),
+    (
+        pytest.param("MÿClass", "cp1252", id="cp12542_file"),
+        pytest.param("My\u0081Class", "utf-8", id="utf8_file"),
+    ),
+)
+def test_encodings(tmp_path, classname, actual_encoding, assumed_encoding):
     """Test handling of different source file encodings."""
+    # write file as bytes with `actual_encoding`
     filepath = tmp_path / "ignore_comments.py"
-    file_contents = "class MýÇlåss:\n    pass"
-    actual_encoding = "latin-1"
+    file_contents = f"class {classname}:\n    pass"
     with open(filepath, "wb") as file:
         file.write(file_contents.encode(actual_encoding))
-    if assumed_encoding == actual_encoding:
-        context = nullcontext
-    else:
+    # this should fail on the ÿ in MÿClass. It represents the (presumed rare) case where
+    # a user's editor saved the source file in cp1252 (or anything other than utf-8).
+    if actual_encoding == "cp1252" and assumed_encoding == "utf-8":
         context = partial(
             pytest.raises,
             UnicodeDecodeError,
-            match="can't decode byte 0xfd in position 7: invalid start byte",
+            match="can't decode byte 0xff in position 7: invalid start byte",
         )
+    # this is the more likely case: file was utf-8 encoded, but Python on Windows uses
+    # the system codepage to read the file. This case is fixed by numpy/numpydoc#510
+    elif actual_encoding == "utf-8" and assumed_encoding == "cp1252":
+        context = partial(
+            pytest.raises,
+            UnicodeDecodeError,
+            match="can't decode byte 0x81 in position 9: character maps to <undefined>",
+        )
+    else:
+        context = nullcontext
     with context():
         result = validate.extract_ignore_validation_comments(filepath, assumed_encoding)
         assert result == {}

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -120,6 +120,7 @@ IGNORE_COMMENT_PATTERN = re.compile("(?:.* numpydoc ignore[=|:] ?)(.+)")
 @functools.lru_cache(maxsize=2000)
 def extract_ignore_validation_comments(
     filepath: Optional[os.PathLike],
+    encoding: str = "utf-8",
 ) -> Dict[int, List[str]]:
     """
     Extract inline comments indicating certain validation checks should be ignored.
@@ -136,7 +137,7 @@ def extract_ignore_validation_comments(
     """
     numpydoc_ignore_comments = {}
     try:
-        file = open(filepath)
+        file = open(filepath, encoding=encoding)
     except (OSError, TypeError):  # can be None, nonexistent, or unreadable
         return numpydoc_ignore_comments
     with file:


### PR DESCRIPTION
(This is a PR-as-issue, but if I've guessed the wrong solution please feel free to close or suggest a better fix.)

An MNE-Python user who was trying to build our docs on Windows hit this error today:

```
Traceback (most recent call last):
  File "C:\Users\Carina\mambaforge\envs\mnedev\Lib\site-packages\sphinx\events.py", line 97, in emit
    results.append(listener.handler(self.app, *args))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Carina\mambaforge\envs\mnedev\Lib\site-packages\numpydoc\numpydoc.py", line 214, in mangle_docstrings
    report = validate(doc)
             ^^^^^^^^^^^^^
  File "C:\Users\Carina\mambaforge\envs\mnedev\Lib\site-packages\numpydoc\validate.py", line 617, in validate
    ignore_validation_comments = extract_ignore_validation_comments(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Carina\mambaforge\envs\mnedev\Lib\site-packages\numpydoc\validate.py", line 145, in extract_ignore_validation_comments
    for token in tokenize.generate_tokens(file.readline):
  File "C:\Users\Carina\mambaforge\envs\mnedev\Lib\tokenize.py", line 454, in _tokenize
    line = readline()
           ^^^^^^^^^^
  File "C:\Users\Carina\mambaforge\envs\mnedev\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 3922: character maps to <undefined>
```

re-running after `export PYTHONUTF8=1` resolved the issue, so I think explicitly invoking `utf-8` during read should also prevent the error without requiring any user action. 

Technically I think this is a backwards-incompatible change for windows users who had any non-ASCII characters in their source files *if those characters are encoded differently in utf-8 than they are in the system's default codepage* (which will vary with OS language settings).  However, `PYTHONUTF8=1` [will become the effective default](https://peps.python.org/pep-0686/) in 2025 with the release of Python 3.15 (so affected users will need to address this change eventually anyway).