### PR TITLE
Update python versions in CI: in particular add python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         sphinx-version:
           [
             "sphinx==5.0",
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Dear maintainers,

this pull request adds python 3.12 to the continuous integration.
Related to #512.

Thanks for considering it.