### PR TITLE
Filter `DeprecationWarning` in failing test for python 3.12  

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         sphinx-version:
           [
             "sphinx==5.0",
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         sphinx-version:
           [
             "sphinx==5.0",
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -1348,6 +1348,7 @@ class TestValidator:
         assert isinstance(errors, list)
         assert errors
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     @pytest.mark.parametrize(
         "klass,func,msgs",
         [


### PR DESCRIPTION
Dear maintainers,

it seems to me that the failing test in #522 and #512 is generated by a `DeprecationWarning` new in python 3.12.
This pull request fixes the test filtering `DeprecationWarning`s in that specific test.

Closes #512.
Closes #522.

Thank you for considering it.