### PR TITLE
PERF: wrap inspect.getsourcelines with cache

### DIFF
--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -7,7 +7,7 @@ with all the detected errors.
 """
 
 from copy import deepcopy
-from typing import Dict, List, Set, Optional
+from typing import Dict, List, Set, Optional, Any
 import ast
 import collections
 import functools
@@ -299,7 +299,7 @@ class Validator:
     # When calling validate, files are parsed twice
     @staticmethod
     @functools.lru_cache(maxsize=4000)
-    def _getsourcelines(obj):
+    def _getsourcelines(obj: Any):
         return inspect.getsourcelines(obj)
 
     @property


### PR DESCRIPTION
While looking into some docstring checks for pandas I saw the opportunity to shave off about 1s of our remaining 7s runtime of numpydoc functions by wrapping `inspect.getsourcelines` with a cache since it usually gets called twice with the same arguments and it is comparatively expensive.