### PR TITLE
Use trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Build Wheel and Release
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  pypi-publish:
+    name: upload release to PyPI
+    if: github.repository_owner == 'numpy' && startsWith(github.ref, 'refs/tags/v') && github.actor == 'jarrodmillman' && always()
+    runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: "3.12"
+
+      - name: Build wheels
+        run: |
+          git clean -fxd
+          pip install -U build twine wheel
+          python -m build --sdist --wheel
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
I enabled GH as a trusted publisher for PyPI:
![2024-03-22T08:06:39,067261850-07:00](https://github.com/numpy/numpydoc/assets/123428/1331892f-867b-4f5c-b93f-2d6a366f7d85)
