### PR TITLE
Unify CLIs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,10 +50,10 @@ jobs:
 
       - name: Make sure CLI works
         run: |
-          python -m numpydoc numpydoc.tests.test_main._capture_stdout
-          echo '! python -m numpydoc numpydoc.tests.test_main._invalid_docstring' | bash
-          python -m numpydoc --validate numpydoc.tests.test_main._capture_stdout
-          echo '! python -m numpydoc --validate numpydoc.tests.test_main._docstring_with_errors' | bash
+          numpydoc render numpydoc.tests.test_main._capture_stdout
+          echo '! numpydoc render numpydoc.tests.test_main._invalid_docstring' | bash
+          numpydoc validate numpydoc.tests.test_main._capture_stdout
+          echo '! numpydoc validate numpydoc.tests.test_main._docstring_with_errors' | bash
 
       - name: Setup for doc build
         run: |
@@ -101,10 +101,10 @@ jobs:
 
       - name: Make sure CLI works
         run: |
-          python -m numpydoc numpydoc.tests.test_main._capture_stdout
-          echo '! python -m numpydoc numpydoc.tests.test_main._invalid_docstring' | bash
-          python -m numpydoc --validate numpydoc.tests.test_main._capture_stdout
-          echo '! python -m numpydoc --validate numpydoc.tests.test_main._docstring_with_errors' | bash
+          numpydoc render numpydoc.tests.test_main._capture_stdout
+          echo '! numpydoc render numpydoc.tests.test_main._invalid_docstring' | bash
+          numpydoc validate numpydoc.tests.test_main._capture_stdout
+          echo '! numpydoc validate numpydoc.tests.test_main._docstring_with_errors' | bash
 
       - name: Setup for doc build
         run: |

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: numpydoc-validation
   name: numpydoc-validation
   description: This hook validates that docstrings in committed files adhere to numpydoc standards.
-  entry: validate-docstrings
+  entry: numpydoc lint
   require_serial: true
   language: python
   types: [python]

--- a/doc/validation.rst
+++ b/doc/validation.rst
@@ -22,7 +22,7 @@ command line options for this hook:
 
 .. code-block:: bash
 
-    $ python -m numpydoc.hooks.validate_docstrings --help
+    $ numpydoc lint --help
 
 Using a config file provides additional customization. Both ``pyproject.toml``
 and ``setup.cfg`` are supported; however, if the project contains both
@@ -102,12 +102,12 @@ can be called. For example, to do it for ``numpy.ndarray``, use:
 
 .. code-block:: bash
 
-    $ python -m numpydoc numpy.ndarray
+    $ numpydoc validate numpy.ndarray
 
 This will validate that the docstring can be built.
 
 For an exhaustive validation of the formatting of the docstring, use the
-``--validate`` parameter. This will report the errors detected, such as
+``validate`` subcommand. This will report the errors detected, such as
 incorrect capitalization, wrong order of the sections, and many other
 issues. Note that this will honor :ref:`inline ignore comments <inline_ignore_comments>`,
 but will not look for any configuration like the :ref:`pre-commit hook <pre_commit_hook>`

--- a/numpydoc/__main__.py
+++ b/numpydoc/__main__.py
@@ -2,55 +2,6 @@
 Implementing `python -m numpydoc` functionality.
 """
 
-import sys
-import argparse
-import ast
+from .cli import main
 
-from .docscrape_sphinx import get_doc_object
-from .validate import validate, Validator
-
-
-def render_object(import_path, config=None):
-    """Test numpydoc docstring generation for a given object"""
-    # TODO: Move Validator._load_obj to a better place than validate
-    print(get_doc_object(Validator._load_obj(import_path), config=dict(config or [])))
-    return 0
-
-
-def validate_object(import_path):
-    exit_status = 0
-    results = validate(import_path)
-    for err_code, err_desc in results["errors"]:
-        exit_status += 1
-        print(":".join([import_path, err_code, err_desc]))
-    return exit_status
-
-
-if __name__ == "__main__":
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("import_path", help="e.g. numpy.ndarray")
-
-    def _parse_config(s):
-        key, _, value = s.partition("=")
-        value = ast.literal_eval(value)
-        return key, value
-
-    ap.add_argument(
-        "-c",
-        "--config",
-        type=_parse_config,
-        action="append",
-        help="key=val where val will be parsed by literal_eval, "
-        "e.g. -c use_plots=True. Multiple -c can be used.",
-    )
-    ap.add_argument(
-        "--validate", action="store_true", help="validate the object and report errors"
-    )
-    args = ap.parse_args()
-
-    if args.validate:
-        exit_code = validate_object(args.import_path)
-    else:
-        exit_code = render_object(args.import_path, args.config)
-
-    sys.exit(exit_code)
+raise SystemExit(main())

--- a/numpydoc/cli.py
+++ b/numpydoc/cli.py
@@ -1,0 +1,68 @@
+"""The CLI for numpydoc."""
+
+import argparse
+import ast
+from typing import Sequence, Union
+
+from .docscrape_sphinx import get_doc_object
+from .hooks import validate_docstrings
+from .validate import Validator, validate
+
+
+def render_object(import_path: str, config: Union[list[str], None] = None) -> int:
+    """Test numpydoc docstring generation for a given object."""
+    # TODO: Move Validator._load_obj to a better place than validate
+    print(get_doc_object(Validator._load_obj(import_path), config=dict(config or [])))
+    return 0
+
+
+def validate_object(import_path: str) -> int:
+    """Run numpydoc docstring validation for a given object."""
+    exit_status = 0
+    results = validate(import_path)
+    for err_code, err_desc in results["errors"]:
+        exit_status += 1
+        print(":".join([import_path, err_code, err_desc]))
+    return exit_status
+
+
+def main(argv: Union[Sequence[str], None] = None) -> int:
+    """CLI for numpydoc."""
+    ap = argparse.ArgumentParser(prog="numpydoc", description=__doc__)
+    subparsers = ap.add_subparsers(title="subcommands")
+
+    def _parse_config(s):
+        key, _, value = s.partition("=")
+        value = ast.literal_eval(value)
+        return key, value
+
+    render = subparsers.add_parser(
+        "render",
+        description="Test numpydoc docstring generation for a given object.",
+        help="generate the docstring with numpydoc",
+    )
+    render.add_argument("import_path", help="e.g. numpy.ndarray")
+    render.add_argument(
+        "-c",
+        "--config",
+        type=_parse_config,
+        action="append",
+        help="key=val where val will be parsed by literal_eval, "
+        "e.g. -c use_plots=True. Multiple -c can be used.",
+    )
+    render.set_defaults(func=render_object)
+
+    validate = subparsers.add_parser(
+        "validate",
+        description="Validate the docstring with numpydoc.",
+        help="validate the object and report errors",
+    )
+    validate.add_argument("import_path", help="e.g. numpy.ndarray")
+    validate.set_defaults(func=validate_object)
+
+    lint_parser = validate_docstrings.get_parser(parent=subparsers)
+    lint_parser.set_defaults(func=validate_docstrings.run_hook)
+
+    args = vars(ap.parse_args(argv))
+    func = args.pop("func", render_object)
+    return func(**args)

--- a/numpydoc/cli.py
+++ b/numpydoc/cli.py
@@ -2,14 +2,14 @@
 
 import argparse
 import ast
-from typing import Sequence, Union
+from typing import List, Sequence, Union
 
 from .docscrape_sphinx import get_doc_object
 from .hooks import validate_docstrings
 from .validate import Validator, validate
 
 
-def render_object(import_path: str, config: Union[list[str], None] = None) -> int:
+def render_object(import_path: str, config: Union[List[str], None] = None) -> int:
     """Test numpydoc docstring generation for a given object."""
     # TODO: Move Validator._load_obj to a better place than validate
     print(get_doc_object(Validator._load_obj(import_path), config=dict(config or [])))

--- a/numpydoc/cli.py
+++ b/numpydoc/cli.py
@@ -64,5 +64,8 @@ def main(argv: Union[Sequence[str], None] = None) -> int:
     lint_parser.set_defaults(func=validate_docstrings.run_hook)
 
     args = vars(ap.parse_args(argv))
-    func = args.pop("func", render_object)
-    return func(**args)
+    try:
+        func = args.pop("func")
+        return func(**args)
+    except KeyError:
+        ap.exit(status=2, message=ap.format_help())

--- a/numpydoc/hooks/validate_docstrings.py
+++ b/numpydoc/hooks/validate_docstrings.py
@@ -1,6 +1,5 @@
 """Run numpydoc validation on contents of a file."""
 
-import argparse
 import ast
 import configparser
 import os
@@ -339,81 +338,6 @@ def process_file(filepath: os.PathLike, config: dict) -> "list[list[str]]":
     docstring_visitor.visit(module_node)
 
     return docstring_visitor.findings
-
-
-def get_parser(
-    parent: Union[argparse.ArgumentParser, None] = None,
-) -> argparse.ArgumentParser:
-    """
-    Build an argument parser.
-
-    Parameters
-    ----------
-    parent : argparse.ArgumentParser
-        A parent parser to use, if this should be a subparser.
-
-    Returns
-    -------
-    argparse.ArgumentParser
-        The argument parser.
-    """
-    project_root_from_cwd, config_file = find_project_root(["."])
-    config_options = parse_config(project_root_from_cwd)
-    ignored_checks = (
-        "\n  "
-        + "\n  ".join(
-            [
-                f"- {check}: {validate.ERROR_MSGS[check]}"
-                for check in set(validate.ERROR_MSGS.keys()) - config_options["checks"]
-            ]
-        )
-        + "\n"
-    )
-
-    description = (
-        "Run numpydoc validation on files with option to ignore individual checks."
-    )
-    if parent is None:
-        parser = argparse.ArgumentParser(
-            description=description,
-            formatter_class=argparse.RawTextHelpFormatter,
-        )
-    else:
-        parser = parent.add_parser(
-            "lint",
-            description=description,
-            help="validate all docstrings in file(s) using the abstract syntax tree",
-        )
-
-    parser.add_argument(
-        "files", type=str, nargs="+", help="File(s) to run numpydoc validation on."
-    )
-    parser.add_argument(
-        "--config",
-        type=str,
-        help=(
-            "Path to a directory containing a pyproject.toml or setup.cfg file.\n"
-            "The hook will look for it in the root project directory.\n"
-            "If both are present, only pyproject.toml will be used.\n"
-            "Options must be placed under\n"
-            "    - [tool:numpydoc_validation] for setup.cfg files and\n"
-            "    - [tool.numpydoc_validation] for pyproject.toml files."
-        ),
-    )
-    parser.add_argument(
-        "--ignore",
-        type=str,
-        nargs="*",
-        help=(
-            f"""Check codes to ignore.{
-                ' Currently ignoring the following from '
-                f'{Path(project_root_from_cwd) / config_file}: {ignored_checks}'
-                'Values provided here will be in addition to the above, unless an alternate config is provided.'
-                if config_options["checks"] else ''
-            }"""
-        ),
-    )
-    return parser
 
 
 def run_hook(

--- a/numpydoc/hooks/validate_docstrings.py
+++ b/numpydoc/hooks/validate_docstrings.py
@@ -13,7 +13,7 @@ except ImportError:
     import tomli as tomllib
 
 from pathlib import Path
-from typing import Any, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from tabulate import tabulate
 
@@ -341,7 +341,22 @@ def process_file(filepath: os.PathLike, config: dict) -> "list[list[str]]":
     return docstring_visitor.findings
 
 
-def get_parser(parent=None):
+def get_parser(
+    parent: Union[argparse.ArgumentParser, None] = None,
+) -> argparse.ArgumentParser:
+    """
+    Build an argument parser.
+
+    Parameters
+    ----------
+    parent : argparse.ArgumentParser
+        A parent parser to use, if this should be a subparser.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The argument parser.
+    """
     project_root_from_cwd, config_file = find_project_root(["."])
     config_options = parse_config(project_root_from_cwd)
     ignored_checks = (
@@ -402,10 +417,10 @@ def get_parser(parent=None):
 
 
 def run_hook(
-    files: list[str],
+    files: List[str],
     *,
-    config: Union[dict[str, Any], None] = None,
-    ignore: Union[list[str], None] = None,
+    config: Union[Dict[str, Any], None] = None,
+    ignore: Union[List[str], None] = None,
 ) -> int:
     """
     Run the numpydoc validation hook.

--- a/numpydoc/tests/hooks/test_validate_hook.py
+++ b/numpydoc/tests/hooks/test_validate_hook.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from numpydoc.hooks.validate_docstrings import main
+from numpydoc.hooks.validate_docstrings import get_parser, run_hook
 
 
 @pytest.fixture
@@ -18,6 +18,11 @@ def example_module(request):
         / "example_module.py"
     )
     return str(fullpath.relative_to(request.config.rootdir))
+
+
+def hook_main(args):
+    parser = get_parser()
+    return run_hook(**vars(parser.parse_args(args)))
 
 
 @pytest.mark.parametrize("config", [None, "fake_dir"])
@@ -76,7 +81,7 @@ def test_validate_hook(example_module, config, capsys):
     if config:
         args.append(f"--{config=}")
 
-    return_code = main(args)
+    return_code = hook_main(args)
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected
 
@@ -109,7 +114,8 @@ def test_validate_hook_with_ignore(example_module, capsys):
         """
     )
 
-    return_code = main([example_module, "--ignore", "ES01", "SA01", "EX01"])
+    return_code = hook_main([example_module, "--ignore", "ES01", "SA01", "EX01"])
+
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected
 
@@ -157,7 +163,7 @@ def test_validate_hook_with_toml_config(example_module, tmp_path, capsys):
         """
     )
 
-    return_code = main([example_module, "--config", str(tmp_path)])
+    return_code = hook_main([example_module, "--config", str(tmp_path)])
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected
 
@@ -196,7 +202,7 @@ def test_validate_hook_with_setup_cfg(example_module, tmp_path, capsys):
         """
     )
 
-    return_code = main([example_module, "--config", str(tmp_path)])
+    return_code = hook_main([example_module, "--config", str(tmp_path)])
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected
 
@@ -205,7 +211,7 @@ def test_validate_hook_help(capsys):
     """Test that help section is displaying."""
 
     with pytest.raises(SystemExit):
-        return_code = main(["--help"])
+        return_code = hook_main(["--help"])
         assert return_code == 0
 
     out = capsys.readouterr().out
@@ -255,7 +261,7 @@ def test_validate_hook_exclude_option_pyproject(example_module, tmp_path, capsys
         """
     )
 
-    return_code = main([example_module, "--config", str(tmp_path)])
+    return_code = hook_main([example_module, "--config", str(tmp_path)])
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected
 
@@ -292,6 +298,6 @@ def test_validate_hook_exclude_option_setup_cfg(example_module, tmp_path, capsys
         """
     )
 
-    return_code = main([example_module, "--config", str(tmp_path)])
+    return_code = hook_main([example_module, "--config", str(tmp_path)])
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected

--- a/numpydoc/tests/hooks/test_validate_hook.py
+++ b/numpydoc/tests/hooks/test_validate_hook.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from numpydoc.hooks.validate_docstrings import get_parser, run_hook
+from numpydoc.hooks.validate_docstrings import run_hook
 
 
 @pytest.fixture
@@ -18,11 +18,6 @@ def example_module(request):
         / "example_module.py"
     )
     return str(fullpath.relative_to(request.config.rootdir))
-
-
-def hook_main(args):
-    parser = get_parser()
-    return run_hook(**vars(parser.parse_args(args)))
 
 
 @pytest.mark.parametrize("config", [None, "fake_dir"])
@@ -77,11 +72,7 @@ def test_validate_hook(example_module, config, capsys):
         """
     )
 
-    args = [example_module]
-    if config:
-        args.append(f"--{config=}")
-
-    return_code = hook_main(args)
+    return_code = run_hook([example_module], config=config)
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected
 
@@ -114,7 +105,7 @@ def test_validate_hook_with_ignore(example_module, capsys):
         """
     )
 
-    return_code = hook_main([example_module, "--ignore", "ES01", "SA01", "EX01"])
+    return_code = run_hook([example_module], ignore=["ES01", "SA01", "EX01"])
 
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected
@@ -163,7 +154,7 @@ def test_validate_hook_with_toml_config(example_module, tmp_path, capsys):
         """
     )
 
-    return_code = hook_main([example_module, "--config", str(tmp_path)])
+    return_code = run_hook([example_module], config=tmp_path)
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected
 
@@ -202,21 +193,9 @@ def test_validate_hook_with_setup_cfg(example_module, tmp_path, capsys):
         """
     )
 
-    return_code = hook_main([example_module, "--config", str(tmp_path)])
+    return_code = run_hook([example_module], config=tmp_path)
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected
-
-
-def test_validate_hook_help(capsys):
-    """Test that help section is displaying."""
-
-    with pytest.raises(SystemExit):
-        return_code = hook_main(["--help"])
-        assert return_code == 0
-
-    out = capsys.readouterr().out
-    assert "--ignore" in out
-    assert "--config" in out
 
 
 def test_validate_hook_exclude_option_pyproject(example_module, tmp_path, capsys):
@@ -261,7 +240,7 @@ def test_validate_hook_exclude_option_pyproject(example_module, tmp_path, capsys
         """
     )
 
-    return_code = hook_main([example_module, "--config", str(tmp_path)])
+    return_code = run_hook([example_module], config=tmp_path)
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected
 
@@ -298,6 +277,6 @@ def test_validate_hook_exclude_option_setup_cfg(example_module, tmp_path, capsys
         """
     )
 
-    return_code = hook_main([example_module, "--config", str(tmp_path)])
+    return_code = run_hook([example_module], config=tmp_path)
     assert return_code == 1
     assert capsys.readouterr().err.rstrip() == expected

--- a/numpydoc/tests/test_main.py
+++ b/numpydoc/tests/test_main.py
@@ -145,3 +145,15 @@ def test_lint(capsys, args):
     err = capsys.readouterr().err.strip("\n\r")
     assert err == expected
     assert return_status == expected_status
+
+
+def test_validate_hook_help(capsys):
+    """Test that help section is displaying."""
+
+    with pytest.raises(SystemExit):
+        return_code = numpydoc.cli.main(["lint", "--help"])
+        assert return_code == 0
+
+    out = capsys.readouterr().out
+    assert "--ignore" in out
+    assert "--config" in out

--- a/numpydoc/tests/test_main.py
+++ b/numpydoc/tests/test_main.py
@@ -147,8 +147,8 @@ def test_lint(capsys, args):
     assert return_status == expected_status
 
 
-def test_validate_hook_help(capsys):
-    """Test that help section is displaying."""
+def test_lint_help(capsys):
+    """Test that lint help section is displaying."""
 
     with pytest.raises(SystemExit):
         return_code = numpydoc.cli.main(["lint", "--help"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ test = [
 ]
 
 [project.scripts]
-validate-docstrings = 'numpydoc.hooks.validate_docstrings:main'
+numpydoc = 'numpydoc.cli:main'
 
 [tool.changelist]
 title_template = "{version}"


### PR DESCRIPTION
Changes:
- Created `numpydoc` entry point (replacing the hook's entry point).
- Moved CLI logic out of `__main__.py` and into a dedicated `cli.py` file.
- Refactored the CLI to use subparsers and treat each of the unique functionalities as a subcommand like `git`: `render`, `validate`, and `lint`.
- Updated `test_main.py` for changes and addition of `lint` option.
- Removed the `-m` option from the hook, so that usage is now from `numpydoc lint`.
- Updated the entry point for the pre-commit hook to `numpydoc lint`.
- Updated validation docs.
- Updated the `test.yml` workflow, but I didn't add a corresponding `lint` command as I don't fully understand what that part does.

Closes https://github.com/numpy/numpydoc/issues/467