### PR TITLE
Fix typo in label-check.yml

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types:
       - opened
-      - repoened
+      - reopened
       - labeled
       - unlabeled
       - synchronize


### PR DESCRIPTION
I thought maybe that was why the check fails, but it seems to be something wrong with line 20, which shows up as incorrect syntax in my editor.