### PR TITLE
DEV: Rm xfails from pytest summary.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,6 @@ numpydoc = [
 
 [tool.pytest.ini_options]
 addopts = '''
---showlocals --doctest-modules -ra --cov-report= --cov=numpydoc
+--showlocals --doctest-modules --cov-report= --cov=numpydoc
 --junit-xml=junit-results.xml --ignore=doc/ --ignore=tools/'''
 junit_family = 'xunit2'


### PR DESCRIPTION
I propose to update the pytest configuration so that the xfails are *not* included in the error summary. IMO this improves the development experience as the xfails clog up the log, making it harder to interpret and obfuscating real failures. The xfails are "expected" after all, so no need to summarize them each time the test suite is run.

Here are the [`pytest` docs](https://docs.pytest.org/en/7.1.x/how-to/output.html#producing-a-detailed-summary-report) I found to figure out how to disable this. The default is `-rfE`, which only shows failures and errors.