### PR TITLE
FIX: coroutines can have a return statement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
             source venv/bin/activate
             python -m pip install --upgrade pip wheel setuptools
             python -m pip install --upgrade -r requirements/doc.txt
+            python -m pip install 'sphinx!=7.3.*'
             python -m pip list
       - save_cache:
           key: pip-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,10 @@ jobs:
         os: [Ubuntu]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         sphinx-version:
-          ["sphinx==6.0", "sphinx==6.2", "sphinx==7.0", "sphinx>=7.2"]
+          ["sphinx==6.0", "sphinx==6.2", "sphinx==7.0", "'sphinx>=7.2,<7.3'"]
+        exclude:
+          - python-version: "3.8"
+            sphinx-version: "'sphinx>=7.2,<7.3'"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,7 @@ jobs:
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install --pre -r requirements/test.txt -r requirements/doc.txt
           python -m pip install codecov
+          python -m pip install 'sphinx!=7.3.*'
           python -m pip list
 
       - name: Install

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -394,12 +394,8 @@ class NumpyDocString(Mapping):
         sections = list(self._read_sections())
         section_names = {section for section, content in sections}
 
-        has_returns = "Returns" in section_names
         has_yields = "Yields" in section_names
         # We could do more tests, but we are not. Arbitrarily.
-        if has_returns and has_yields:
-            msg = "Docstring contains both a Returns and Yields section."
-            raise ValueError(msg)
         if not has_yields and "Receives" in section_names:
             msg = "Docstring contains a Receives section but not Yields."
             raise ValueError(msg)

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -280,8 +280,8 @@ b : int
 
 """
     doc = NumpyDocString(doc_text)
-    assert len(doc['Returns']) == 1
-    assert len(doc['Yields']) == 2
+    assert len(doc["Returns"]) == 1
+    assert len(doc["Yields"]) == 2
 
 
 def test_section_twice():

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -279,7 +279,9 @@ b : int
     The number of bananas.
 
 """
-    assert_raises(ValueError, NumpyDocString, doc_text)
+    doc = NumpyDocString(doc_text)
+    assert len(doc['Returns']) == 1
+    assert len(doc['Yields']) == 2
 
 
 def test_section_twice():


### PR DESCRIPTION
The value returned by the coroutine is carried on the `StopIteration` Exception that is raised when exhausted.


This is a follow up to https://github.com/numpy/numpydoc/pull/145 which allows documenting.  This came up in the discussions then (https://github.com/numpy/numpydoc/issues/47#issuecomment-344104267), but I missed that it was forbidden!