### PR TITLE
BUG: Fix bug with validation encoding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,11 +66,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt install texlive texlive-latex-extra latexmk dvipng
+        if: runner.os == 'Linux'
 
       - name: Build documentation
         run: |
           make -C doc html SPHINXOPTS="-nT"
           make -C doc latexpdf SPHINXOPTS="-nT"
+        if: runner.os == 'Linux'
 
   prerelease:
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
             sphinx-version: "sphinx" # version shouldn't really matter here
     defaults:
       run:
-        shell: bash -euo pipefail
+        shell: bash -e
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
             sphinx-version: "sphinx" # version shouldn't really matter here
     defaults:
       run:
-        shell: bash -euo pipefail {0}
+        shell: bash -eo pipefail {0}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
             sphinx-version: "sphinx" # version shouldn't really matter here
     defaults:
       run:
-        shell: bash -e
+        shell: bash -euo pipefail {0}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         sphinx-version:
           ["sphinx==6.0", "sphinx==6.2", "sphinx==7.0", "sphinx>=7.3"]
+        include:
+          - os: Windows
+            python-version: "3.12"
+            sphinx-version: "sphinx" # version shouldn't really matter here
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
           - os: Windows
             python-version: "3.12"
             sphinx-version: "sphinx" # version shouldn't really matter here
+    defaults:
+      run:
+        shell: bash -euo pipefail
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
True TDD, should fail on this first commit. If it doesn't I'll push until it does. Then I think we just need a `open(..., encoding="utf-8")` here

https://github.com/numpy/numpydoc/blob/1454aa93f19989e1f5ce3fb6c19d2fca49b61fdd/numpydoc/hooks/validate_docstrings.py#L121