### PR TITLE
See Also Parser Recognizes Sphinx XREF

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -257,14 +257,16 @@ class NumpyDocString(Mapping):
     # <FUNCNAME> is one of
     #   <PLAIN_FUNCNAME>
     #   COLON <ROLE> COLON BACKTICK <PLAIN_FUNCNAME> BACKTICK
+    #   COLON <ROLE> COLON BACKTICK <PLAIN_FUNCNAME> RIGHT_ANGLE_BRACKET <TARGET_NAME> LEFT_ANGLE_BRACKET BACKTICK
     # where
+    #   <TARGET_NAME> is a legal sphinx target for cross-linking
     #   <PLAIN_FUNCNAME> is a legal function name, and
     #   <ROLE> is any nonempty sequence of word characters.
-    # Examples: func_f1  :meth:`func_h1` :obj:`~baz.obj_r` :class:`class_j`
+    # Examples: func_f1  :meth:`func_h1` :obj:`~baz.obj_r` :class:`class_j` :class:`class_j <class_j>`
     # <DESC> is a string describing the function.
 
     _role = r":(?P<role>(py:)?\w+):"
-    _funcbacktick = r"`(?P<name>(?:~\w+\.)?[a-zA-Z0-9_\.-]+)`"
+    _funcbacktick = r"`(?P<name>(?:~\w+\.)?[a-zA-Z0-9_\.-]+)\s?(?P<target_name>(?:\s?\<\w)[a-zA-Z0-9_\.-]+(?:\>))?`"
     _funcplain = r"(?P<name2>[a-zA-Z0-9_\.-]+)"
     _funcname = r"(" + _role + _funcbacktick + r"|" + _funcplain + r")"
     _funcnamenext = _funcname.replace("role", "rolenext")
@@ -300,7 +302,7 @@ class NumpyDocString(Mapping):
         items = []
 
         def parse_item_name(text):
-            """Match ':role:`name`' or 'name'."""
+            """Match ':role:`name`', ':role:`name <target>`' or 'name'."""
             m = self._func_rgx.match(text)
             if not m:
                 self._error_location(f"Error parsing See Also entry {line!r}")


### PR DESCRIPTION
The See Also section raises a ValueError when it encounters a valid sphinx cross-reference such as 

```rst
:meth:`QImage.save <QImage.save>
```

This commit allows the regex to parse the sphinx target, which is the section between the angled brackets.

Author Note: This is my first contribution to a repo such as this, so I likely missed something, comments/nit-picks welcome.