### PR TITLE
In linter, ignore @overload functions

### DIFF
--- a/numpydoc/hooks/validate_docstrings.py
+++ b/numpydoc/hooks/validate_docstrings.py
@@ -61,6 +61,11 @@ class AstValidator(validate.Validator):
         return isinstance(self.node, (ast.FunctionDef, ast.AsyncFunctionDef))
 
     @property
+    def is_overload(self) -> bool:
+        decorators = getattr(self.node, "decorator_list", [])
+        return any(d.id == "overload" for d in decorators)
+
+    @property
     def is_generator_function(self) -> bool:
         if not self.is_function_or_method:
             return False

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -278,6 +278,12 @@ class Validator:
         return inspect.isfunction(self.obj)
 
     @property
+    def is_overload(self) -> bool:
+        # Not sure how to figure out when a function is overloaded
+        # without looking at its AST
+        return False
+
+    @property
     def is_generator_function(self):
         return inspect.isgeneratorfunction(_unwrap(self.obj))
 
@@ -633,7 +639,8 @@ def validate(obj_name, validator_cls=None, **validator_kwargs):
 
     errs = []
     if not doc.raw_doc:
-        if "GL08" not in ignore_validation_comments:
+        # Check if we are dealing with a `typing.overload` function
+        if "GL08" not in ignore_validation_comments and not doc.is_overload:
             errs.append(error("GL08"))
         return {
             "type": doc.type,


### PR DESCRIPTION
See #559

This PR makes the *linter* behave correctly, but not the validator.

The piece I am missing is figuring out how, without the AST, to see whether we are dealing with the `@overload` function definition, or the "real" function definition.

This is easy in the linter, as we can get decorator information from the AST.

Is it OK to have some functionality work only in the linter @rossbar?