### PR TITLE
Use intersphinx registry to avoid out of date links.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -138,14 +138,6 @@ latex_documents = [
 
 # -- Intersphinx setup ----------------------------------------------------
 
-# Example configuration for intersphinx: refer to the Python standard library.
-<<<<<<< intersphinx_registry
+# Example configuration for intersphinx: refer to several Python libraries.
 
 intersphinx_mapping = get_intersphinx_mapping(packages=["python", "numpy", "sklearn"])
-=======
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
-    "sklearn": ("https://scikit-learn.org/stable/", None),
-}
->>>>>>> main

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,6 +14,8 @@ from datetime import date
 
 import numpydoc
 
+from intersphinx_registry import get_intersphinx_mapping
+
 # for example.py
 sys.path.insert(0, os.path.abspath("."))
 # project root
@@ -137,8 +139,5 @@ latex_documents = [
 # -- Intersphinx setup ----------------------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-    "numpy": ("https://numpy.org/devdocs/", None),
-    "sklearn": ("https://scikit-learn.org/stable/", None),
-}
+
+intersphinx_mapping = get_intersphinx_mapping(["python", "numpy", "sklearn"])

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,9 +12,9 @@ import os
 import sys
 from datetime import date
 
-import numpydoc
-
 from intersphinx_registry import get_intersphinx_mapping
+
+import numpydoc
 
 # for example.py
 sys.path.insert(0, os.path.abspath("."))

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -140,4 +140,4 @@ latex_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 
-intersphinx_mapping = get_intersphinx_mapping(["python", "numpy", "sklearn"])
+intersphinx_mapping = get_intersphinx_mapping(packages=["python", "numpy", "sklearn"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ doc = [
     'matplotlib>=3.5',
     'pydata-sphinx-theme>=0.13.3',
     'sphinx>=7',
+    'intersphinx_registry',
 ]
 test = [
     'pytest',

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,3 +4,4 @@ numpy>=1.22
 matplotlib>=3.5
 pydata-sphinx-theme>=0.13.3
 sphinx>=7
+intersphinx_registry


### PR DESCRIPTION
This avoids some of the issues we saw in #525