### PR TITLE
Do not rely on requirements.txt in ci, use .[test,doc]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,14 +37,13 @@ jobs:
       - name: Setup environment
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          python -m pip install -r requirements/test.txt -r requirements/doc.txt
           python -m pip install codecov
           python -m pip install ${{ matrix.sphinx-version }}
           python -m pip list
 
       - name: Install
         run: |
-          python -m pip install .
+          python -m pip install .[test,doc]
           pip list
 
       - name: Run test suite
@@ -91,13 +90,12 @@ jobs:
       - name: Setup environment
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          python -m pip install --pre -r requirements/test.txt -r requirements/doc.txt
           python -m pip install codecov
           python -m pip list
 
       - name: Install
         run: |
-          python -m pip install .
+          python -m pip install .[test,doc]
           pip list
 
       - name: Run test suite


### PR DESCRIPTION
This is one step toward not needing those file and having one less command to sugest to users.