### PR TITLE
Fix navbar for documentation pages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -82,7 +82,7 @@ pygments_style = "sphinx"
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "show_prev_next": False,
-    "navbar_end": ["theme-switcher", "search-field.html", "navbar-icon-links.html"],
+    "navbar_end": ["theme-switcher", "navbar-icon-links.html"],
     "icon_links": [
         {
             "name": "GitHub",


### PR DESCRIPTION
I noticed something went wrong and two different search fields were showing in the top navbar for the docs website, causing the navbar items to wrap. This PR removes the extra search field.

Before:

![Captura de imagem_20240620_160713](https://github.com/numpy/numpydoc/assets/3949932/e96663c7-3ec1-4eb4-9751-5cbcae34be00)

This PR:

![Captura de imagem_20240620_160743](https://github.com/numpy/numpydoc/assets/3949932/45ed6ca1-995a-4040-bf6d-c88fcc4f639d)
