### PR TITLE
Move "Attributes" and "Methods" below "Parameters"

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -120,17 +120,17 @@ class NumpyDocString(Mapping):
         "Summary": [""],
         "Extended Summary": [],
         "Parameters": [],
+        "Attributes": [],
+        "Methods": [],
         "Returns": [],
         "Yields": [],
         "Receives": [],
+        "Other Parameters": [],
         "Raises": [],
         "Warns": [],
-        "Other Parameters": [],
-        "Attributes": [],
-        "Methods": [],
+        "Warnings": [],
         "See Also": [],
         "Notes": [],
-        "Warnings": [],
         "References": "",
         "Examples": "",
         "index": {},
@@ -549,8 +549,10 @@ class NumpyDocString(Mapping):
         out += self._str_signature()
         out += self._str_summary()
         out += self._str_extended_summary()
+        out += self._str_param_list("Parameters")
+        for param_list in ("Attributes", "Methods"):
+            out += self._str_param_list(param_list)
         for param_list in (
-            "Parameters",
             "Returns",
             "Yields",
             "Receives",
@@ -563,8 +565,6 @@ class NumpyDocString(Mapping):
         out += self._str_see_also(func_role)
         for s in ("Notes", "References", "Examples"):
             out += self._str_section(s)
-        for param_list in ("Attributes", "Methods"):
-            out += self._str_param_list(param_list)
         out += self._str_index()
         return "\n".join(out)
 

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -359,6 +359,12 @@ class SphinxDocString(NumpyDocString):
             "summary": self._str_summary(),
             "extended_summary": self._str_extended_summary(),
             "parameters": self._str_param_list("Parameters"),
+            "attributes": (
+                self._str_param_list("Attributes", fake_autosummary=True)
+                if self.attributes_as_param_list
+                else self._str_member_list("Attributes")
+            ),
+            "methods": self._str_member_list("Methods"),
             "returns": self._str_returns("Returns"),
             "yields": self._str_returns("Yields"),
             "receives": self._str_returns("Receives"),
@@ -370,12 +376,6 @@ class SphinxDocString(NumpyDocString):
             "notes": self._str_section("Notes"),
             "references": self._str_references(),
             "examples": self._str_examples(),
-            "attributes": (
-                self._str_param_list("Attributes", fake_autosummary=True)
-                if self.attributes_as_param_list
-                else self._str_member_list("Attributes")
-            ),
-            "methods": self._str_member_list("Methods"),
         }
         ns = {k: "\n".join(v) for k, v in ns.items()}
 

--- a/numpydoc/templates/numpydoc_docstring.rst
+++ b/numpydoc/templates/numpydoc_docstring.rst
@@ -2,6 +2,8 @@
 {{summary}}
 {{extended_summary}}
 {{parameters}}
+{{attributes}}
+{{methods}}
 {{returns}}
 {{yields}}
 {{receives}}
@@ -13,5 +15,3 @@
 {{notes}}
 {{references}}
 {{examples}}
-{{attributes}}
-{{methods}}

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1203,6 +1203,17 @@ class_doc_txt = """
     b
     c
 
+    Other Parameters
+    ----------------
+
+    another parameter : str
+        This parameter is less important.
+
+    Notes
+    -----
+
+    Some notes about the class.
+
     Examples
     --------
     For usage examples, see `ode`.
@@ -1222,10 +1233,6 @@ def test_class_members_doc():
         Aaa.
     jac : callable ``jac(t, y, *jac_args)``
         Bbb.
-
-    Examples
-    --------
-    For usage examples, see `ode`.
 
     Attributes
     ----------
@@ -1250,6 +1257,21 @@ def test_class_members_doc():
     a
     b
     c
+
+    Other Parameters
+    ----------------
+
+    another parameter : str
+        This parameter is less important.
+
+    Notes
+    -----
+
+    Some notes about the class.
+
+    Examples
+    --------
+    For usage examples, see `ode`.
 
     """,
     )
@@ -1304,10 +1326,6 @@ def test_class_members_doc_sphinx():
         **jac** : callable ``jac(t, y, *jac_args)``
             Bbb.
 
-    .. rubric:: Examples
-
-    For usage examples, see `ode`.
-
     :Attributes:
 
         **t** : float
@@ -1344,6 +1362,19 @@ def test_class_members_doc_sphinx():
     **b**
     **c**
     =====  ==========
+
+    .. rubric:: Other Parameters
+
+    **another parameter** : str
+        This parameter is less important.
+
+    .. rubric:: Notes
+
+    Some notes about the class.
+
+    .. rubric:: Examples
+
+    For usage examples, see `ode`.
 
     """,
     )

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1260,13 +1260,11 @@ def test_class_members_doc():
 
     Other Parameters
     ----------------
-
     another parameter : str
         This parameter is less important.
 
     Notes
     -----
-
     Some notes about the class.
 
     Examples
@@ -1363,10 +1361,10 @@ def test_class_members_doc_sphinx():
     **c**
     =====  ==========
 
-    .. rubric:: Other Parameters
+    :Other Parameters:
 
-    **another parameter** : str
-        This parameter is less important.
+        **another parameter** : str
+            This parameter is less important.
 
     .. rubric:: Notes
 


### PR DESCRIPTION
Reorder the sections in `docscrape` to match the style guide. As per https://numpydoc.readthedocs.io/en/latest/format.html#class-docstring, the Attributes section should be "located below the Parameters section", which I am interpreting as directly below. It seems wrong for Attributes to be below Notes, References and Examples.

x-ref https://github.com/scipy/scipy/issues/21099