### PR TITLE
Dedent section starting with `.. deprecation::`

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -206,7 +206,7 @@ class NumpyDocString(Mapping):
 
             section += self._doc.read_to_next_empty_line()
 
-        return section
+        return dedent_lines(section)
 
     def _read_sections(self):
         while not self._doc.eof():

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -576,6 +576,8 @@ class NumpyDocString(Mapping):
 
 def dedent_lines(lines):
     """Deindent a list of lines maximally"""
+    if not lines:
+        return lines
     return textwrap.dedent("\n".join(lines)).split("\n")
 
 

--- a/numpydoc/tests/hooks/example_module.py
+++ b/numpydoc/tests/hooks/example_module.py
@@ -60,3 +60,21 @@ class NewClass:
             A failing constructor implementation without parameters.
             """
             self.name = name
+
+
+def deprecated_function():
+    """Compute my function.
+
+    .. deprecated:: v0.1
+        This function is listed for future removal.
+
+    What it does in more detail.
+
+    See Also
+    --------
+    related : Something related.
+
+    Examples
+    --------
+    >>> result = 1 + 1
+    """


### PR DESCRIPTION
Closes https://github.com/numpy/numpydoc/issues/573

There may be a more elegant way to fix this. Problem is that section that starts with deprecation warning comes back indented, and therefore fails to meet the test `doc.extended_summary.startswith(".. deprecated:: ")`.

Reproducer:

`foo.py`:

```
def my_func_right():
    """Compute my function.

    .. deprecated:: v0.1
        This function is listed for future removal.

    What it does in more detail.
    """
    pass
```

```
$ numpydoc lint foo.py
```