### PR TITLE
docscrape: fixes from SciPy

### DIFF
--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -344,7 +344,7 @@ class NumpyDocString(Mapping):
 
     def _parse_index(self, section, content):
         """
-        .. index: default
+        .. index:: default
            :refguide: something, else, and more
 
         """
@@ -446,7 +446,7 @@ class NumpyDocString(Mapping):
         if error:
             raise ValueError(msg)
         else:
-            warn(msg)
+            warn(msg, stacklevel=3)
 
     # string conversion routines
 


### PR DESCRIPTION
x-ref https://github.com/scipy/scipy/pull/21215 where we are bringing our vendored `docscrape` up to date with upstream. @mdhaber found a bug which is fixed here.

Also, our linter caught a `warn` without a `stacklevel` kwarg. Please consider adding `ruff` code `B028` for this repo!