### PR TITLE
MAINT: Remove scale to work around PyPI bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,36 @@
 name: Build Wheel and Release
 on:
+  pull_request:
+    branches:
+      - main
   push:
     tags:
       - v*
 
 jobs:
+  sdist_wheel:
+    name: sdist and wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build wheels
+        run: |
+          git clean -fxd
+          pip install -U build twine wheel
+          python -m build --sdist --wheel
+      - run: twine check --strict dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+
   pypi-publish:
+    needs: sdist_wheel
     name: upload release to PyPI
     if: github.repository_owner == 'numpy' && startsWith(github.ref, 'refs/tags/v') && github.actor == 'jarrodmillman' && always()
     runs-on: ubuntu-latest
@@ -15,20 +40,8 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: "3.12"
-
-      - name: Build wheels
-        run: |
-          git clean -fxd
-          pip install -U build twine wheel
-          python -m build --sdist --wheel
-
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,6 @@ numpydoc -- Numpy's Sphinx extensions
 
 .. image:: https://readthedocs.org/projects/numpydoc/badge/?version=latest
    :alt: Documentation Status
-   :scale: 100%
    :target: https://numpydoc.readthedocs.io/en/latest/
 
 .. image:: https://codecov.io/gh/numpy/numpydoc/branch/main/graph/badge.svg


### PR DESCRIPTION
Works around https://github.com/pypa/readme_renderer/issues/304 by removing `:scale:` which doesn't seem necessary anyway. Also makes the `twine check --strict` part of all PR runs to catch this sort of thing sooner and make sure we don't break our packaging somehow.

Closes #577

Locally in an isolated env I get that it passes the `twine check`