### PR TITLE
MAINT: Add _exception_on_warning to MockApp

### DIFF
--- a/numpydoc/tests/test_numpydoc.py
+++ b/numpydoc/tests/test_numpydoc.py
@@ -49,6 +49,7 @@ class MockApp:
         self.verbosity = 2
         self._warncount = 0
         self.warningiserror = False
+        self._exception_on_warning = False
 
 
 def test_mangle_docstrings_basic():


### PR DESCRIPTION
The test suite has started failing with:

```
AttributeError: 'MockApp' object has no attribute '_exception_on_warning'
```

This started happening with the release of sphinx 8.1, and from a quick look at the changelog is likely related to sphinx-doc/sphinx#12743.

Since the failures are only related to the existence of attributes on a `MockApp` object used to simulate a sphinx-app instance in the numpydoc test suite, it should be okay to just patch the mocked object with the missing attr.