### PR TITLE
MAINT: Changed class constructor __init__ GL08 reporting

### DIFF
--- a/doc/format.rst
+++ b/doc/format.rst
@@ -557,7 +557,8 @@ Class docstring
 Use the same sections as outlined above (all except :ref:`Returns <returns>`
 are applicable).  The constructor (``__init__``) should also be documented
 here, the :ref:`Parameters <params>` section of the docstring details the
-constructor's parameters.
+constructor's parameters. The class docstring does not need to be repeated
+in a constructor, but is optional.
 
 An **Attributes** section, located below the :ref:`Parameters <params>`
 section, may be used to describe non-method attributes of the class::

--- a/doc/validation.rst
+++ b/doc/validation.rst
@@ -183,6 +183,9 @@ inline comments:
         def __init__(self):  # numpydoc ignore=GL08
             pass
 
+Note, if the :ref:`class <_classdoc>` docstring properly documents the
+constructor, the ``GL08`` will be ignored by default.
+
 This is supported by the :ref:`CLI <validation_via_cli>`,
 :ref:`pre-commit hook <pre_commit_hook>`, and
 :ref:`Sphinx extension <validation_during_sphinx_build>`.

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -633,7 +633,23 @@ def validate(obj_name, validator_cls=None, **validator_kwargs):
 
     errs = []
     if not doc.raw_doc:
-        if "GL08" not in ignore_validation_comments:
+        report_GL08: bool = True
+        # Check if the object is a class and has a docstring in the constructor
+        if doc.name.endswith("__init__") and doc.is_function_or_method:
+            cls_name = doc.code_obj.__qualname__.split(".")[0]
+            cls = getattr(importlib.import_module(doc.code_obj.__module__), cls_name)
+            cls_doc = Validator(get_doc_object(cls))
+
+            # Parameter_mismatches, PR01, PR02, PR03 are checked for the class docstring.
+            # If cls_doc has PR01, PR02, PR03 errors, i.e. invalid class docstring,
+            # then we also report missing constructor docstring, GL08.
+            report_GL08 = len(cls_doc.parameter_mismatches) > 0
+
+        # Check if GL08 is to be ignored:
+        if "GL08" in ignore_validation_comments:
+            report_GL08 = False
+        # Add GL08 error?
+        if report_GL08:
             errs.append(error("GL08"))
         return {
             "type": doc.type,


### PR DESCRIPTION
Changed `validate` function in `validate.py` for empty docstring error `GL08` ("The object does not have a docstring"), specifically for `__init__` constructors. If an empty docstring for `__init__`, will first check if class docstring is satisfied for parameter mismatches, before deciding to report `GL08` (if mismatches exist, i.e. incomplete documentation).

Implemented new docstring test classes in `test_validate.py` to verify correct functionality.
Also updated readthedocs `format.rst` and `validation.rst` to reflect new changes to constructor checking behavior.

Solves https://github.com/numpy/numpydoc/issues/591.

Note, I think a modification to the readthedocs  https://numpydoc.readthedocs.io/en/latest/validation.html#ignoring-validation-checks-with-inline-comments ought to be made 

P.s. First time pull requesting to a public repo, let me know if anything is insufficient.