### PR TITLE
don't pass maxsplit as positional arg

### DIFF
--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -160,7 +160,7 @@ class SphinxDocString(NumpyDocString):
         display_param = f":obj:`{param} <{link_prefix}{param}>`"
         if obj_doc:
             # Overwrite desc. Take summary logic of autosummary
-            desc = re.split(r"\n\s*\n", obj_doc.strip(), 1)[0]
+            desc = re.split(r"\n\s*\n", obj_doc.strip(), maxsplit=1)[0]
             # XXX: Should this have DOTALL?
             #      It does not in autosummary
             m = re.search(r"^([A-Z].*?\.)(?:\s|$)", " ".join(desc.split()))


### PR DESCRIPTION
Py3.13 introduces a warning when passing `re.split(..., maxsplit)` as positional. This PR changes it to a kwarg.

xref: https://github.com/python/cpython/pull/107778