### PR TITLE
Fix *args as positional arguments

### DIFF
--- a/doc/format.rst
+++ b/doc/format.rst
@@ -228,7 +228,7 @@ When documenting variable length positional, or keyword arguments, leave the
 leading star(s) in front of the name and do not specify a type::
 
   *args
-      Additional arguments should be passed as keyword arguments
+      Additional arguments should be passed as positional arguments.
   **kwargs
       Extra arguments to `metric`: refer to each metric documentation for a
       list of all possible arguments.


### PR DESCRIPTION
This PR fixes the wording to describe `*args` as _positional_ arguments, and adds a full stop at the end.