### PR TITLE
Fix typo in validation.rst

### DIFF
--- a/doc/validation.rst
+++ b/doc/validation.rst
@@ -184,7 +184,7 @@ inline comments:
             pass
 
 Note that a properly formatted :ref:`class <classdoc>` docstring
-silences ``G08`` for an ``__init__`` constructor without a docstring.
+silences ``GL08`` for an ``__init__`` constructor without a docstring.
 
 This is supported by the :ref:`CLI <validation_via_cli>`,
 :ref:`pre-commit hook <pre_commit_hook>`, and


### PR DESCRIPTION
The docs now reference a non-existent rule (G08), which, based on https://github.com/numpy/numpydoc/pull/592, I believe should be GL08.

I also think that line is a little misleading since that does not apply to the pre-commit hook or `numpydoc lint`, which both use the `AstValidator`.