### PR TITLE
BUG: Correct functionality of numpydoc SS05

### DIFF
--- a/numpydoc/tests/hooks/example_module.py
+++ b/numpydoc/tests/hooks/example_module.py
@@ -23,8 +23,8 @@ class MyClass:
         *args
         """
 
-    def process(self):
-        """Process stuff."""
+    def create(self):
+        """Creates stuff."""
 
 
 class NewClass:

--- a/numpydoc/tests/hooks/test_validate_hook.py
+++ b/numpydoc/tests/hooks/test_validate_hook.py
@@ -116,9 +116,7 @@ def test_validate_hook_with_toml_config(example_module, tmp_path, capsys):
                 ]
                 exclude = '\\.__init__$'
                 override_SS05 = [
-                    '^Process',
-                    '^Assess',
-                    '^Access',
+                    '^Creates',
                 ]
                 """
             )
@@ -154,7 +152,7 @@ def test_validate_hook_with_setup_cfg(example_module, tmp_path, capsys):
                 [tool:numpydoc_validation]
                 checks = all,EX01,SA01,ES01
                 exclude = \\.__init__$
-                override_SS05 = ^Process,^Assess,^Access
+                override_SS05 = ^Creates
                 """
             )
         )
@@ -198,9 +196,7 @@ def test_validate_hook_exclude_option_pyproject(example_module, tmp_path, capsys
                     '\.__init__$',
                 ]
                 override_SS05 = [
-                    '^Process',
-                    '^Assess',
-                    '^Access',
+                    '^Creates',
                 ]
                 """
             )
@@ -232,7 +228,7 @@ def test_validate_hook_exclude_option_setup_cfg(example_module, tmp_path, capsys
                 [tool:numpydoc_validation]
                 checks = all,EX01,SA01,ES01
                 exclude = \\.NewClass$,\\.__init__$
-                override_SS05 = ^Process,^Assess,^Access
+                override_SS05 = ^Creates
                 """
             )
         )

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -711,7 +711,12 @@ def validate(obj_name, validator_cls=None, **validator_kwargs):
             errs.append(error("SS03"))
         if doc.summary != doc.summary.lstrip():
             errs.append(error("SS04"))
-        elif doc.is_function_or_method and doc.summary.split(" ")[0][-1] == "s":
+        # Heuristic to check for infinitive verbs - shouldn't end in "s"
+        elif (
+            doc.is_function_or_method
+            and doc.summary.split(" ")[0][-1] == "s"
+            and doc.summary.split(" ")[0][-2] != "s"
+        ):
             errs.append(error("SS05"))
         if doc.num_summary_lines > 1:
             errs.append(error("SS06"))

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -714,6 +714,7 @@ def validate(obj_name, validator_cls=None, **validator_kwargs):
         # Heuristic to check for infinitive verbs - shouldn't end in "s"
         elif (
             doc.is_function_or_method
+            and len(doc.summary.split(" ")[0]) > 1
             and doc.summary.split(" ")[0][-1] == "s"
             and doc.summary.split(" ")[0][-2] != "s"
         ):

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -80,8 +80,7 @@ ERROR_MSGS = {
     "PR06": 'Parameter "{param_name}" type should use "{right_type}" instead '
     'of "{wrong_type}"',
     "PR07": 'Parameter "{param_name}" has no description',
-    "PR08": 'Parameter "{param_name}" description should start with a '
-    "capital letter",
+    "PR08": 'Parameter "{param_name}" description should start with a capital letter',
     "PR09": 'Parameter "{param_name}" description should finish with "."',
     "PR10": 'Parameter "{param_name}" requires a space before the colon '
     "separating the parameter name and type",


### PR DESCRIPTION
Currently SS05 checks for infinitive verbs by checking if the last character is "s". However, if the first word is "process", which is valid, this incorrectly throws a numpydoc validation error.

This commit allows the first word to end in two "s"es without flagging as an error. This will allow for words like "process" or "progress," while still checking for invalid words like "creates."

I wasn't sure if I should open an issue for this too, I thought it would be easiest to just find the error and submit a PR, but I'm happy to open an issue as well. 