### PR TITLE
Fix pip setup command in github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install codecov
-          python -m pip install ${{ matrix.sphinx-version }}
+          python -m pip install "${{ matrix.sphinx-version }}"
           python -m pip list
 
       - name: Install


### PR DESCRIPTION
In [the workflow](https://github.com/numpy/numpydoc/blob/main/.github/workflows/test.yml#L41), `python -m pip install sphinx>=7.3` seems misinterpreted as `python -m pip install sphinx` with the stdout being redirected to a file named `=7.3`.