### PR TITLE
MAINT: Make pre-commit run --all pass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -25,7 +25,7 @@ repos:
         args: [--prose-wrap=preserve]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "9c89adb347f6b973f4905a4be0051eb2ecf85dea"  # frozen: v0.13.3
+    rev: "9c89adb347f6b973f4905a4be0051eb2ecf85dea" # frozen: v0.13.3
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes", "--exit-non-zero-on-fix"]

--- a/numpydoc/docscrape.py
+++ b/numpydoc/docscrape.py
@@ -597,7 +597,7 @@ class FunctionDoc(NumpyDocString):
     def __str__(self):
         out = ""
 
-        func, func_name = self.get_func()
+        _func, func_name = self.get_func()
 
         roles = {"func": "function", "meth": "method"}
 

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -211,7 +211,7 @@ def test_parameters(doc):
 def test_other_parameters(doc):
     assert len(doc["Other Parameters"]) == 1
     assert [n for n, _, _ in doc["Other Parameters"]] == ["spam"]
-    arg, arg_type, desc = doc["Other Parameters"][0]
+    _arg, arg_type, desc = doc["Other Parameters"][0]
     assert arg_type == "parrot"
     assert desc[0].startswith("A parrot off its mortal coil")
 

--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -1391,11 +1391,8 @@ class TestValidator:
         ],
     )
     def test_bad_generic_functions(self, capsys, func):
-        with pytest.warns(UserWarning):
-            errors = validate_one(
-                self._import_path(klass="WarnGenericFormat", func=func)
-            )
-        assert "is too short" in w.msg
+        with pytest.warns(UserWarning, match="is too short"):
+            validate_one(self._import_path(klass="WarnGenericFormat", func=func))
 
     @pytest.mark.parametrize(
         "func",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ extend-select = [
 ignore = [
   "PLR09",    # Too many <...>
   "PLR2004",  # Magic value used in comparison
+  "PLC0415",  # Imports not at top of file (we often nest intentionally)
   "ISC001",   # Conflicts with formatter
   "ARG001",   # FIXME: consider removing this and the following rules from this list
   "ARG002",


### PR DESCRIPTION
Not really sure how these snuck through, but this should get pre-commit.ci green again. Seems trivial so I'll self-merge once green, but happy to make a follow-up PR if people have comments.