### PR TITLE
Remove duplicate dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ Source = 'https://github.com/numpy/numpydoc/'
 [dependency-groups]
 dev = [
     'pre-commit>=3.3',
-    "tomli; python_version < '3.11'",
     { include-group = "doc" },
     { include-group = "test" }
 ]


### PR DESCRIPTION
Remove `tomli` dev dependency for Python versions >= 3.11 since it is already in the package dependencies section (line 31)