### PR TITLE
Fix test warnings about invalid regex escape

### DIFF
--- a/numpydoc/tests/hooks/test_validate_hook.py
+++ b/numpydoc/tests/hooks/test_validate_hook.py
@@ -250,7 +250,7 @@ def test_validate_hook_exclude_option_setup_cfg(example_module, tmp_path, capsys
 
 @pytest.mark.parametrize(
     "regex, expected_code",
-    [(".*(/|\\\\)example.*\.py", 0), (".*/non_existent_match.*\.py", 1)],
+    [(r".*(/|\\\\)example.*\.py", 0), (r".*/non_existent_match.*\.py", 1)],
 )
 def test_validate_hook_exclude_files_option_pyproject(
     example_module, regex, expected_code, tmp_path
@@ -287,7 +287,7 @@ def test_validate_hook_exclude_files_option_pyproject(
 
 @pytest.mark.parametrize(
     "regex, expected_code",
-    [(".*(/|\\\\)example.*\.py", 0), (".*/non_existent_match.*\.py", 1)],
+    [(r".*(/|\\\\)example.*\.py", 0), (r".*/non_existent_match.*\.py", 1)],
 )
 def test_validate_hook_exclude_files_option_setup_cfg(
     example_module, regex, expected_code, tmp_path


### PR DESCRIPTION
I just noticed when looking at the test runs in #653 that there are some warnings about invalid escape sequences:

<img width="768" height="324" alt="Screenshot 2025-10-21 at 5 49 36 PM" src="https://github.com/user-attachments/assets/e853643a-284e-4c15-91cb-a06f8cd13e7f" />

This PR marks the strings in question as raw strings to fix it.