### PR TITLE
CI version updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install
         run: |
-          python -m pip install . --group test --group doc
+          python -m pip install --pre . --group test --group doc
           pip list
 
       - name: Run test suite


### PR DESCRIPTION
Two minor updates to the CI:
 1. Add Python3.14 to the default (i.e. latest sphinx) testing matrix
 2. Add the `--pre` flag to the job named "prerelease"

I suspect number 2 was intended - regardless, it's definitely worthwhile to test against sphinx rc's in particular.

There are more extensive CI changes that I think are worthwhile - for example, the testing matrix for old sphinx versions include sphinx/Python combos for which there are no wheels (e.g. sphinx v6 only supplies wheels up to Python3.11, but we test with 3.12 and 3.13 there too). Such changes might warrant more discussion so I'll save them for a separate PR - the two changes should be uncontroversial.