### PR TITLE
Support abbreviations in property summaries

### DIFF
--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -14,6 +14,10 @@ from .xref import make_xref
 
 IMPORT_MATPLOTLIB_RE = r"\b(import +matplotlib|from +matplotlib +import)\b"
 
+# Used to help identify the first sentence of an object's description. These
+# values are based on sphinx.ext.autosummary.
+WELL_KNOWN_ABBREVIATIONS = ('et al.', 'e.g.', 'i.e.', 'vs.')
+
 
 class SphinxDocString(NumpyDocString):
     def __init__(self, docstring, config=None):
@@ -159,16 +163,22 @@ class SphinxDocString(NumpyDocString):
         # Referenced object has a docstring
         display_param = f":obj:`{param} <{link_prefix}{param}>`"
         if obj_doc:
-            # Overwrite desc. Take summary logic of autosummary
-            desc = re.split(r"\n\s*\n", obj_doc.strip(), maxsplit=1)[0]
-            # XXX: Should this have DOTALL?
-            #      It does not in autosummary
-            m = re.search(r"^([A-Z].*?\.)(?:\s|$)", " ".join(desc.split()))
-            if m:
-                desc = m.group(1).strip()
+            # Overwrite desc with the first sentence. Based on
+            # sphinx.ext.autosummary's `extract_summary()`.
+            stanza = re.split(r"\n\s*\n", obj_doc.strip(), maxsplit=1)[0]
+            sentences = re.split(r"\.(?:\s+|$)", " ".join(stanza.split()))
+            if len(sentences) == 1:
+                # If there are no periods, use only the first line. This
+                # differs from autosummary, which takes the whole stanza.
+                desc = stanza.partition("\n")[0]
             else:
-                desc = desc.partition("\n")[0]
-            desc = desc.split("\n")
+                desc = ''
+                for i in range(len(sentences)):
+                    desc = '. '.join(sentences[: i + 1]).rstrip('.') + '.'
+                    if not desc.endswith(WELL_KNOWN_ABBREVIATIONS):
+                        break
+            desc = [desc]
+
         return display_param, desc
 
     def _str_param_list(self, name, fake_autosummary=False):

--- a/numpydoc/docscrape_sphinx.py
+++ b/numpydoc/docscrape_sphinx.py
@@ -16,7 +16,7 @@ IMPORT_MATPLOTLIB_RE = r"\b(import +matplotlib|from +matplotlib +import)\b"
 
 # Used to help identify the first sentence of an object's description. These
 # values are based on sphinx.ext.autosummary.
-WELL_KNOWN_ABBREVIATIONS = ('et al.', 'e.g.', 'i.e.', 'vs.')
+WELL_KNOWN_ABBREVIATIONS = ("et al.", "e.g.", "i.e.", "vs.")
 
 
 class SphinxDocString(NumpyDocString):
@@ -172,9 +172,9 @@ class SphinxDocString(NumpyDocString):
                 # differs from autosummary, which takes the whole stanza.
                 desc = stanza.partition("\n")[0]
             else:
-                desc = ''
+                desc = ""
                 for i in range(len(sentences)):
-                    desc = '. '.join(sentences[: i + 1]).rstrip('.') + '.'
+                    desc = ". ".join(sentences[: i + 1]).rstrip(".") + "."
                     if not desc.endswith(WELL_KNOWN_ABBREVIATIONS):
                         break
             desc = [desc]

--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1198,6 +1198,7 @@ class_doc_txt = """
         But a description
     no_docstring2 : str
     multiline_sentence
+    multiline_single_sentence
     midword_period
     no_period
 
@@ -1253,6 +1254,7 @@ def test_class_members_doc():
         But a description
     no_docstring2 : str
     multiline_sentence
+    multiline_single_sentence
     midword_period
     no_period
 
@@ -1298,6 +1300,12 @@ def test_class_members_doc_sphinx():
         def multiline_sentence(self):
             """This is a
             sentence. It spans multiple lines."""
+            return
+
+        @property
+        def multiline_single_sentence(self):
+            """This is a
+            sentence."""
             return
 
         @property
@@ -1349,6 +1357,9 @@ def test_class_members_doc_sphinx():
             ..
 
         :obj:`multiline_sentence <multiline_sentence>`
+            This is a sentence.
+
+        :obj:`multiline_single_sentence <multiline_single_sentence>`
             This is a sentence.
 
         :obj:`midword_period <midword_period>`
@@ -1417,6 +1428,53 @@ def test_class_attributes_as_member_list():
     cfg = dict(attributes_as_param_list=False)
     assert attr_doc2 in str(SphinxClassDoc(Foo, config=cfg))
     assert "Another description" not in str(SphinxClassDoc(Foo, config=cfg))
+
+
+def test_class_properties_with_abbreviations():
+    class Foo:
+        """
+        Class docstring.
+
+        Attributes
+        ----------
+        using_ie
+        using_ie_in_parens
+        using_others
+        """
+
+        @property
+        def using_ie(self):
+            """
+            Test property, i.e. a method that works like an attribute. More.
+            """
+            return
+
+        @property
+        def using_ie_in_parens(self):
+            """
+            Test property (i.e. a method that works like an attribute). More.
+            """
+            return
+
+        @property
+        def using_others(self):
+            """
+            Test others et al. and e.g. and vs. are ok. More.
+            """
+            return
+
+    attr_doc = """:Attributes:
+
+    :obj:`using_ie <using_ie>`
+        Test property, i.e. a method that works like an attribute.
+
+    :obj:`using_ie_in_parens <using_ie_in_parens>`
+        Test property (i.e. a method that works like an attribute).
+
+    :obj:`using_others <using_others>`
+        Test others et al. and e.g. and vs. are ok."""
+
+    assert attr_doc in str(SphinxClassDoc(Foo))
 
 
 def test_templated_sections():


### PR DESCRIPTION
This addresses one of the issues in #299, where sphinx.ext.autosummary supports a set of well-known abbreviations (e.g. “e.g.” 😉) in the first sentence of a docstring that is being summarized, but Numpydoc does not.

This only comes into play with properties that are listed in a class’s “Attributes” section. When Numpydoc tries to get the first sentence of a property’s docstring, it gets tripped up by abbreviations with periods and ends the summary after the abbreviation instead of at the actual end of the sentence:

```py
class ExampleClass:
    """
    This is an example of how properties get formatted by numpydoc.

    Attributes
    ----------
    property_attribute
    """

    @property
    def property_attribute(self) -> int:
        """
        This attribute is actually a property (i.e. it's actually a function
        call under the hood).
        """
        return 5
```

Renders the summary of the property as ending with “i.e.”:

<img width="594" height="154" alt="Screenshot of rendered doc output" src="https://github.com/user-attachments/assets/079880b1-aa6d-4bd1-bd08-36eef256ade4" />

## Open Questions/Caveats

My  understanding from the discussion on #299 is that this logic is meant to largely match the behavior of autosummary (current logic in https://github.com/sphinx-doc/sphinx/blob/cc7c6f435ad37bb12264f8118c8461b230e6830c/sphinx/ext/autosummary/__init__.py#L553-L567), but the actual logic seems to have diverged a bit:

1. If there is no period in the opening stanza/paragraph, Autosummary takes the whole stanza, while Numpydoc takes only the first line. There are tests around this, so I assume it’s an intentional difference, and tried to call it out a little more clearly in the source.

2. Numpydoc’s previous implementation attempts to scan up to the first period and stop, while Autosummary splits all the candidate sentences into a list to work with. I don’t know if the difference was an intentional performance concern (what Numpydoc had *should* be faster and lower memory) or if it was drift over time or for some other reason.

    I rewrote the code using the same general structure and logic as Autosummary, so it should be easier update if/when things change there. But I can re-do this using `re.finditer()` if there are performance or other concerns.