### PR TITLE
Add sphinx8 to oldsphinx testing matrix.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [Ubuntu]
         python-version: ["3.10", "3.11"]
-        sphinx-version: ["sphinx<7", "sphinx<8"]
+        sphinx-version: ["sphinx<7", "sphinx<8", "sphinx<9"]
     defaults:
       run:
         shell: bash -eo pipefail {0}


### PR DESCRIPTION
Right now CI tests sphinx major versions 6, 7, and 9 (latest). This adds sphinx v8.