### PR TITLE
FIX: don't evaluate annotations when collecting signature parameters (Python 3.14 / PEP 649)

### DIFF
--- a/numpydoc/tests/test_validate.py
+++ b/numpydoc/tests/test_validate.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -55,6 +56,18 @@ def test_no_file():
     """Test that validation can be done on functions made on the fly."""
     # Just a smoke test for now, <list> will have a None filename
     validate.validate("numpydoc.tests.test_validate._DummyList.clear")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="PEP 649 lazy annotations")
+def test_signature_params_with_typechecking_only_annotation():
+    ns = {}
+    exec("def func(a, b=1, *args, **kwargs) -> OnlyUnderTypeChecking: ...", ns)
+    assert Validator(get_doc_object(ns["func"])).signature_parameters == (
+        "a",
+        "b",
+        "*args",
+        "**kwargs",
+    )
 
 
 @pytest.mark.parametrize(

--- a/numpydoc/validate.py
+++ b/numpydoc/validate.py
@@ -14,6 +14,7 @@ import inspect
 import os
 import pydoc
 import re
+import sys
 import textwrap
 import tokenize
 from copy import deepcopy
@@ -435,7 +436,19 @@ class Validator:
                 # accessor classes have a signature but don't want to show this
                 return tuple()
         try:
-            sig = inspect.signature(self.obj)
+            if sys.version_info >= (3, 14):
+                # PEP 649: on Python 3.14+ ``inspect.signature`` evaluates annotations
+                # eagerly, raising ``NameError`` for forward references that only
+                # resolve under ``TYPE_CHECKING``. Only parameter names and kinds are
+                # used below, so request the forward-ref-preserving format to
+                # introspect the signature without evaluating annotations.
+                import annotationlib
+
+                sig = inspect.signature(
+                    self.obj, annotation_format=annotationlib.Format.FORWARDREF
+                )
+            else:
+                sig = inspect.signature(self.obj)
         except (TypeError, ValueError):
             # Some objects, mainly in C extensions do not support introspection
             # of the signature


### PR DESCRIPTION
Fix suggested by Claude Opus 4.8 on failures observed today while modernizing our SW stack to 3.14+.

On Python 3.14, PEP 649 evaluates annotations lazily and `inspect.signature()` now resolves them (VALUE format) when building the signature. As a result, running numpydoc validation on a callable whose signature annotation references a name that's only importable under `TYPE_CHECKING` raises `NameError` — a common pattern for typing-only imports, especially in modules that can't use `from __future__ import annotations`. `Validator.signature_parameters` guards `inspect.signature()` only against `(TypeError, ValueError)`, so the `NameError` propagates and aborts the Sphinx build (the autodoc-process-docstring handler raises).

`signature_parameters` only uses parameter names and kinds, never the annotation values, so this evaluation is unnecessary. On Python 3.14+ it now introspects with `annotationlib.Format.FORWARDREF`, which returns unresolved forward references as `ForwardRef` objects rather than evaluating (and crashing on) them. Behaviour on Python < 3.14 is unchanged.

Reproducer (Python 3.14):

```python
from typing import TYPE_CHECKING
if TYPE_CHECKING:
    from somewhere import Thing

def build() -> Thing: ...   # module does NOT use `from __future__ import annotations`
```

Validating build previously raised `NameError: name 'Thing' is not defined`; with this change it validates cleanly.