### PR TITLE
Avoid deprecated Sphinx autodoc options mapping

### DIFF
--- a/numpydoc/numpydoc.py
+++ b/numpydoc/numpydoc.py
@@ -190,14 +190,8 @@ def mangle_docstrings(app: SphinxApp, what, name, obj, options, lines):
     if options is not None:
         if isinstance(options, dict):
             cfg.update(options)
-        elif hasattr(options, "from_directive_options"):
-            # Sphinx 9.x _AutoDocumenterOptions
-            cfg.update(vars(options))
         else:
-            try:
-                cfg.update(options or {})
-            except TypeError:
-                cfg.update(options.__dict__ or {})
+            cfg.update(vars(options))
     u_NL = "\n"
     if what == "module":
         # Strip top title

--- a/numpydoc/tests/test_numpydoc.py
+++ b/numpydoc/tests/test_numpydoc.py
@@ -1,4 +1,6 @@
+import warnings
 from collections import defaultdict
+from collections.abc import Mapping
 from copy import deepcopy
 from io import StringIO
 from pathlib import PosixPath
@@ -117,6 +119,32 @@ A top section before
     lines = [x.strip() for x in lines]
     assert ("rpartition" in lines) is has_rpartition
     assert ("upper" in lines) is has_upper
+
+
+def test_mangle_docstrings_does_not_use_deprecated_options_mapping():
+    class DeprecatedMappingOptions(Mapping):
+        def __init__(self):
+            self.exclude_members = {"upper"}
+
+        def __getitem__(self, key):
+            warnings.warn("mapping interface used", DeprecationWarning, stacklevel=2)
+            return vars(self)[key]
+
+        def __iter__(self):
+            warnings.warn("mapping interface used", DeprecationWarning, stacklevel=2)
+            return iter(vars(self))
+
+        def __len__(self):
+            return len(vars(self))
+
+    lines = [".. autoclass:: str"]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        mangle_docstrings(
+            MockApp(), "class", "str", str, DeprecatedMappingOptions(), lines
+        )
+
+    assert "upper" not in [line.strip() for line in lines]
 
 
 def test_mangle_docstrings_inherited_class_members():


### PR DESCRIPTION
## Summary

- read non-dict autodoc options through their instance attributes instead of the deprecated mapping interface
- retain direct dictionary handling for existing callers
- add a regression object whose mapping methods raise deprecation warnings, matching Sphinx 10 behavior

Fixes #679.

## Tests

- `pytest -q` (315 passed, 2 xfailed)
- `pytest numpydoc/tests/test_numpydoc.py -q` (19 passed)
- `ruff check numpydoc/numpydoc.py numpydoc/tests/test_numpydoc.py --ignore TRY004`
- `ruff format --check numpydoc/numpydoc.py numpydoc/tests/test_numpydoc.py`
- `git diff --check`