### PR TITLE
fix: correct typo in test

### DIFF
--- a/numpydoc/tests/test_docscrape.py
+++ b/numpydoc/tests/test_docscrape.py
@@ -1459,7 +1459,7 @@ def test_templated_sections():
 
 
 def test_nonstandard_property():
-    # test discovery of a property that does not satisfy isinstace(.., property)
+    # test discovery of a property that does not satisfy isinstance(.., property)
 
     class SpecialProperty:
         def __init__(self, axis=0, doc=""):


### PR DESCRIPTION
Fixes: isinstace → isinstance in test_docscrape.py